### PR TITLE
Fix 32bit build errors

### DIFF
--- a/zmq.rs
+++ b/zmq.rs
@@ -2,7 +2,7 @@
 Module: zmq
 */
 
-import libc::{c_int, c_long, c_void, size_t, c_char};
+import libc::{c_int, c_long, c_longlong, c_void, size_t, c_char};
 import result::{result, ok, err, chain};
 
 export context;
@@ -85,7 +85,7 @@ native mod zmq {
     fn zmq_send(socket: socket, msg: msg, flags: c_int) -> c_int;
     fn zmq_recv(socket: socket, msg: msg, flags: c_int) -> c_int;
 
-    fn zmq_poll(items: *pollitem, nitems: c_int, timeout: c_long) -> c_int;
+    fn zmq_poll(items: *pollitem, nitems: c_int, timeout: c_longlong) -> c_int;
 }
 
 #[doc = "Socket types"]
@@ -286,7 +286,7 @@ impl socket for socket {
         }
     }
 
-    fn get_fd() -> result<int, error> {
+    fn get_fd() -> result<i64, error> {
         getsockopt_i64(self, constants::ZMQ_FD)
     }
 


### PR DESCRIPTION
This fixes the following errors when building on **32bit Arch Linux**:

```
./zmq.rs:290:8: 290:47 error: mismatched types: expected `core::result::result<int,error>` but found `core::result::result<i64,error>` (int vs i64)
./zmq.rs:290         getsockopt_i64(self, constants::ZMQ_FD)
                     ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
./zmq.rs:476:8: 476:15 error: mismatched types: expected `core::libc::types::os::arch::c95::c_long` but found `i64` (core::libc::types::os::arch::c95::c_long vs i64)
./zmq.rs:476         timeout);
                     ^~~~~~~
```
