### PR TITLE
Update for master.

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,23 +4,26 @@ To build, just run `rustc lib.rs`. rust-zmq is a pretty straight forward
 port of the C API into Rust:
 
     extern mod zmq;
-    
+
+    #[link_args="-lzmq"] // link against the C library
+    extern {}
+
     fn main() {
         let ctx = match zmq::init(1) {
           Ok(ctx) => ctx,
           Err(e) => fail!(e.to_str())
         };
-    
+
         let socket = match ctx.socket(zmq::REQ) {
           Ok(socket) => { socket },
           Err(e) => { fail!(e.to_str()) }
         };
-    
+
         match socket.connect("tcp://127.0.0.1:1234") {
           Ok(()) => (),
           Err(e) => fail!(e.to_str())
         }
-    
+
         match socket.send_str("hello world!", 0) {
           Ok(()) => (),
           Err(e) => fail!(e.to_str())
@@ -39,5 +42,4 @@ Install for developers:
 
     % git clone https://github.com/erickt/rust-zmq
     % cd rust-zmq
-    % make deps
     % make

--- a/src/examples/msgsend/main.rs
+++ b/src/examples/msgsend/main.rs
@@ -12,6 +12,9 @@ use std::comm;
 use std::os;
 use std::task;
 
+#[link_args="-lzmq"]
+extern {}
+
 fn server(pull_socket: zmq::Socket, push_socket: zmq::Socket, mut workers: uint) {
     let mut count = 0u;
     let mut msg = zmq::Message::new();

--- a/src/examples/zguide/helloworld-client/main.rs
+++ b/src/examples/zguide/helloworld-client/main.rs
@@ -2,6 +2,9 @@
 
 extern mod zmq;
 
+#[link_args="-lzmq"]
+extern {}
+
 fn main() {
     println("Conneting to hello world server...\n");
 

--- a/src/examples/zguide/helloworld-server/main.rs
+++ b/src/examples/zguide/helloworld-server/main.rs
@@ -4,7 +4,10 @@
 
 extern mod zmq;
 
-use std::rt;
+use std::io;
+
+#[link_args="-lzmq"]
+extern {}
 
 fn main() {
     #[fixed_stack_segment];
@@ -21,6 +24,6 @@ fn main() {
             println!("Received {}", s);
         }
         responder.send_str("World", 0);
-        rt::io::timer::sleep(1000);
+        io::timer::sleep(1000);
     }
 }

--- a/src/examples/zguide/version/main.rs
+++ b/src/examples/zguide/version/main.rs
@@ -1,5 +1,8 @@
 extern mod zmq;
 
+#[link_args="-lzmq"]
+extern {}
+
 fn main() {
     let (major, minor, patch) = zmq::version();
     println!("Current 0MQ version is {}.{}.{}", major, minor, patch);

--- a/src/examples/zguide/weather-client/main.rs
+++ b/src/examples/zguide/weather-client/main.rs
@@ -6,6 +6,9 @@
 
 extern mod zmq;
 
+#[link_args="-lzmq"]
+extern {}
+
 fn atoi(s: &str) -> int {
     from_str(s).unwrap()
 }

--- a/src/examples/zguide/weather-server/main.rs
+++ b/src/examples/zguide/weather-server/main.rs
@@ -6,6 +6,9 @@ extern mod zmq;
 
 use std::rand::random;
 
+#[link_args="-lzmq"]
+extern {}
+
 fn main() {
     let context = zmq::Context::new();
     let publisher = context.socket(zmq::PUB).unwrap();

--- a/src/zmq/lib.rs
+++ b/src/zmq/lib.rs
@@ -5,8 +5,6 @@
        uuid = "54cc1bc9-02b8-447c-a227-75ebc923bc29")];
 #[crate_type = "lib"];
 
-#[link_args = "-lzmq"];
-
 extern mod extra;
 
 use std::{cast, libc, mem, ptr, str, vec};
@@ -21,35 +19,38 @@ type Socket_ = *c_void;
 /// A message
 type Msg_ = [c_char, ..32];
 
-externfn!(fn zmq_version(major: *c_int, minor: *c_int, patch: *c_int))
+#[link_args = "-lzmq"]
+extern {
+    fn zmq_version(major: *c_int, minor: *c_int, patch: *c_int);
 
-externfn!(fn zmq_ctx_new() -> Context_)
-externfn!(fn zmq_ctx_destroy(ctx: Context_) -> c_int)
+    fn zmq_ctx_new() -> Context_;
+    fn zmq_ctx_destroy(ctx: Context_) -> c_int;
 
-externfn!(fn zmq_errno() -> c_int)
-externfn!(fn zmq_strerror(errnum: c_int) -> *c_char)
+    fn zmq_errno() -> c_int;
+    fn zmq_strerror(errnum: c_int) -> *c_char;
 
-externfn!(fn zmq_socket(ctx: Context_, typ: c_int) -> Socket_)
-externfn!(fn zmq_close(socket: Socket_) -> c_int)
+    fn zmq_socket(ctx: Context_, typ: c_int) -> Socket_;
+    fn zmq_close(socket: Socket_) -> c_int;
 
-externfn!(fn zmq_getsockopt(socket: Socket_, opt: c_int, optval: *c_void, size: *size_t) -> c_int)
-externfn!(fn zmq_setsockopt(socket: Socket_, opt: c_int, optval: *c_void, size: size_t) -> c_int)
+    fn zmq_getsockopt(socket: Socket_, opt: c_int, optval: *c_void, size: *size_t) -> c_int;
+    fn zmq_setsockopt(socket: Socket_, opt: c_int, optval: *c_void, size: size_t) -> c_int;
 
-externfn!(fn zmq_bind(socket: Socket_, endpoint: *c_char) -> c_int)
-externfn!(fn zmq_connect(socket: Socket_, endpoint: *c_char) -> c_int)
+    fn zmq_bind(socket: Socket_, endpoint: *c_char) -> c_int;
+    fn zmq_connect(socket: Socket_, endpoint: *c_char) -> c_int;
 
-externfn!(fn zmq_recv(socket: Socket_, buf: *mut u8, len: size_t, flags: c_int) -> c_int)
+    fn zmq_recv(socket: Socket_, buf: *mut u8, len: size_t, flags: c_int) -> c_int;
 
-externfn!(fn zmq_msg_init(msg: &Msg_) -> c_int)
-externfn!(fn zmq_msg_init_size(msg: &Msg_, size: size_t) -> c_int)
-externfn!(fn zmq_msg_data(msg: &Msg_) -> *u8)
-externfn!(fn zmq_msg_size(msg: &Msg_) -> size_t)
-externfn!(fn zmq_msg_close(msg: &Msg_) -> c_int)
+    fn zmq_msg_init(msg: &Msg_) -> c_int;
+    fn zmq_msg_init_size(msg: &Msg_, size: size_t) -> c_int;
+    fn zmq_msg_data(msg: &Msg_) -> *u8;
+    fn zmq_msg_size(msg: &Msg_) -> size_t;
+    fn zmq_msg_close(msg: &Msg_) -> c_int;
 
-externfn!(fn zmq_msg_send(msg: &Msg_, socket: Socket_, flags: c_int) -> c_int)
-externfn!(fn zmq_msg_recv(msg: &Msg_, socket: Socket_, flags: c_int) -> c_int)
+    fn zmq_msg_send(msg: &Msg_, socket: Socket_, flags: c_int) -> c_int;
+    fn zmq_msg_recv(msg: &Msg_, socket: Socket_, flags: c_int) -> c_int;
 
-externfn!(fn zmq_poll(items: *PollItem, nitems: c_int, timeout: c_long) -> c_int)
+    fn zmq_poll(items: *PollItem, nitems: c_int, timeout: c_long) -> c_int;
+}
 
 /// Socket types
 #[deriving(Clone)]
@@ -414,7 +415,7 @@ impl Socket {
 
     pub fn get_socket_type(&self) -> Result<SocketType, Error> {
         do getsockopt_int(self.sock, ZMQ_TYPE.to_raw()).map |ty| {
-            match *ty {
+            match ty {
                 0 => PAIR,
                 1 => PUB,
                 2 => SUB,


### PR DESCRIPTION
There's no longer a need for `externfn!` (and it's been removed),
`std::rt::io` -> `std::io`. And something about the linking model
changed, so that downstream creates need `#[link_args="-lzmq"]` too.

The extra `link_args` in each of the example crates seem very unfortunate, but I get linking errors without them. :(
