### PR TITLE
make revents public

### DIFF
--- a/src/zmq/lib.rs
+++ b/src/zmq/lib.rs
@@ -643,7 +643,7 @@ pub struct PollItem {
     socket: Socket_,
     fd: c_int,
     events: i16,
-    revents: i16
+    pub revents: i16
 }
 
 pub fn poll(items: &mut [PollItem], timeout: i64) -> Result<(), Error> {


### PR DESCRIPTION
The result of `zmq_poll()` is written to the `revents` field of each relevant `PollItem`. Therefore, this field needs to be accessible. Perhaps it would be nice to provide accessor functions such as `is_poll_out()`, but for now I favor just making `revents` a public field, as in this pull request.
