### PR TITLE
API updates

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,9 @@ authors = [ "erick.tryzelaar@gmail.com" ]
 name = "zmq"
 path = "src/zmq/lib.rs"
 
+[dev-dependencies]
+time = "*"
+
 [[example]]
 name = "msgsend"
 path = "examples/msgsend/main.rs"

--- a/examples/msgsend/main.rs
+++ b/examples/msgsend/main.rs
@@ -51,10 +51,6 @@ fn spawn_server(ctx: &mut zmq::Context, workers: uint) -> comm::Sender<()> {
     let (ready_tx, ready_rx) = comm::channel();
     let (start_tx, start_rx) = comm::channel();
 
-    // Mutable sockets cannot be implicitly captured.
-    let pull_socket = pull_socket;
-    let push_socket = push_socket;
-
     TaskBuilder::new().native().spawn(proc() {
         // Let the main thread know we're ready.
         ready_tx.send(());
@@ -85,9 +81,6 @@ fn spawn_worker(ctx: &mut zmq::Context, count: uint) -> comm::Receiver<()> {
 
     push_socket.connect("inproc://server-pull").unwrap();
     //push_socket.connect("tcp://127.0.0.1:3456").unwrap();
-
-    // Mutable sockets cannot be implicitly captured.
-    let push_socket = push_socket;
 
     // Spawn the worker.
     let (tx, rx) = comm::channel();

--- a/examples/msgsend/main.rs
+++ b/examples/msgsend/main.rs
@@ -20,7 +20,7 @@ fn server(mut pull_socket: zmq::Socket, mut push_socket: zmq::Socket, mut worker
     let mut msg = zmq::Message::new();
 
     while workers != 0 {
-        match pull_socket.recv(&mut msg, 0) {
+        match pull_socket.recv_into(&mut msg, 0) {
             Err(e) => panic!(e.to_string()),
             Ok(()) => {
                 msg.with_str(|s| {
@@ -127,7 +127,7 @@ fn run(ctx: &mut zmq::Context, size: uint, workers: uint) {
     }
 
     // Receive the final count.
-    let result = match pull_socket.recv_msg(0) {
+    let result = match pull_socket.recv(0) {
         Ok(msg) => msg.with_str(|s| from_str::<uint>(s).unwrap()),
         Err(e) => panic!(e.to_string()),
     };

--- a/examples/zguide/helloworld-client/main.rs
+++ b/examples/zguide/helloworld-client/main.rs
@@ -14,7 +14,7 @@ fn main() {
 
     let mut msg = zmq::Message::new();
 
-    for x in range(0i, 10i) {
+    for x in range(0u, 10u) {
         println!("Sending Hello {}", x);
         requester.send_bytes(b"Hello", 0).unwrap();
 

--- a/examples/zguide/helloworld-client/main.rs
+++ b/examples/zguide/helloworld-client/main.rs
@@ -16,7 +16,7 @@ fn main() {
 
     for x in range(0i, 10i) {
         println!("Sending Hello {}", x);
-        requester.send(b"Hello", 0).unwrap();
+        requester.send_bytes(b"Hello", 0).unwrap();
 
         requester.recv(&mut msg, 0).unwrap();
         msg.with_str(|s| {

--- a/examples/zguide/helloworld-client/main.rs
+++ b/examples/zguide/helloworld-client/main.rs
@@ -18,7 +18,7 @@ fn main() {
         println!("Sending Hello {}", x);
         requester.send_bytes(b"Hello", 0).unwrap();
 
-        requester.recv(&mut msg, 0).unwrap();
+        requester.recv_into(&mut msg, 0).unwrap();
         msg.with_str(|s| {
             println!("Received World {}: {}", s, x);
         })

--- a/examples/zguide/helloworld-server/main.rs
+++ b/examples/zguide/helloworld-server/main.rs
@@ -17,7 +17,7 @@ fn main() {
 
     let mut msg = zmq::Message::new();
     loop {
-        responder.recv(&mut msg, 0).unwrap();
+        responder.recv_into(&mut msg, 0).unwrap();
         msg.with_str(|s| {
             println!("Received {}", s);
         });

--- a/examples/zguide/weather-client/main.rs
+++ b/examples/zguide/weather-client/main.rs
@@ -25,7 +25,7 @@ fn main() {
 
     let mut total_temp = 0;
 
-    for _ in range(0i, 100i) {
+    for _ in range(0u, 100u) {
         let string = subscriber.recv_str(0).unwrap();
         let chks: Vec<int> = string.as_slice().split(' ').map(|x| atoi(x)).collect();
         let (_zipcode, temperature, _relhumidity) = (chks[0], chks[1], chks[2]);

--- a/examples/zguide/weather-server/main.rs
+++ b/examples/zguide/weather-server/main.rs
@@ -26,7 +26,7 @@ fn main() {
         // very, very slow. Several orders of magnitude slower than glibc's
         // sprintf
         let update = format!("{:05} {} {}", zipcode, temperature, relhumidity);
-        publisher.send(update.as_bytes(), 0).unwrap();
+        publisher.send_bytes(update.as_bytes(), 0).unwrap();
     }
 
     // note: destructors mean no explicit cleanup necessary

--- a/src/zmq/lib.rs
+++ b/src/zmq/lib.rs
@@ -343,7 +343,7 @@ impl Socket {
     }
 
     /// Send a message
-    pub fn send(&mut self, msg: &mut Message, flags: int) -> Result<(), Error> {
+    pub fn send(&mut self, msg: Message, flags: int) -> Result<(), Error> {
         unsafe {
             let rc = zmq_msg_send(&msg.msg, self.sock, flags as c_int);
             if rc == -1i32 { Err(errno_to_error()) } else { Ok(()) }

--- a/src/zmq/lib.rs
+++ b/src/zmq/lib.rs
@@ -357,7 +357,6 @@ impl Socket {
             ptr::copy_memory(zmq_msg_data(&msg) as *mut u8, base_ptr, len);
 
             let rc = zmq_msg_send(&msg, self.sock, flags as c_int);
-            let _ = zmq_msg_close(&msg);
 
             if rc == -1i32 { Err(errno_to_error()) } else { Ok(()) }
         }

--- a/src/zmq/lib.rs
+++ b/src/zmq/lib.rs
@@ -343,7 +343,14 @@ impl Socket {
     }
 
     /// Send a message
-    pub fn send(&mut self, data: &[u8], flags: int) -> Result<(), Error> {
+    pub fn send(&mut self, msg: &mut Message, flags: int) -> Result<(), Error> {
+        unsafe {
+            let rc = zmq_msg_send(&msg.msg, self.sock, flags as c_int);
+            if rc == -1i32 { Err(errno_to_error()) } else { Ok(()) }
+        }
+    }
+
+    pub fn send_bytes(&mut self, data: &[u8], flags: int) -> Result<(), Error> {
         unsafe {
             let base_ptr = data.as_ptr();
             let len = data.len();
@@ -363,7 +370,7 @@ impl Socket {
     }
 
     pub fn send_str(&mut self, data: &str, flags: int) -> Result<(), Error> {
-        self.send(data.as_bytes(), flags)
+        self.send_bytes(data.as_bytes(), flags)
     }
 
     /// Receive a message into a `Message`. The length passed to zmq_msg_recv

--- a/src/zmq/lib.rs
+++ b/src/zmq/lib.rs
@@ -184,16 +184,16 @@ pub enum Error {
     EPROTO          = posix88::EPROTO as int,
     EPROTONOSUPPORT = posix88::EPROTONOSUPPORT as int,
     // magic number is EHAUSNUMERO + num
-    ENOTSUP         = 156384713,
-    ENOBUFS         = 156384715,
-    ENETDOWN        = 156384716,
-    EADDRNOTAVAIL   = 156384718,
+    ENOTSUP         = 156384713 as int,
+    ENOBUFS         = 156384715 as int,
+    ENETDOWN        = 156384716 as int,
+    EADDRNOTAVAIL   = 156384718 as int,
 
     // native zmq error codes
-    EFSM            = 156384763,
-    ENOCOMPATPROTO  = 156384764,
-    ETERM           = 156384765,
-    EMTHREAD        = 156384766,
+    EFSM            = 156384763 as int,
+    ENOCOMPATPROTO  = 156384764 as int,
+    ETERM           = 156384765 as int,
+    EMTHREAD        = 156384766 as int,
 }
 
 impl Error {

--- a/src/zmq/lib.rs
+++ b/src/zmq/lib.rs
@@ -375,7 +375,7 @@ impl Socket {
 
     /// Receive a message into a `Message`. The length passed to zmq_msg_recv
     /// is the length of the buffer.
-    pub fn recv(&mut self, msg: &mut Message, flags: int) -> Result<(), Error> {
+    pub fn recv_into(&mut self, msg: &mut Message, flags: int) -> Result<(), Error> {
         let rc = unsafe {
             zmq_msg_recv(&msg.msg, self.sock, flags as c_int)
         };
@@ -387,23 +387,23 @@ impl Socket {
         }
     }
 
-    pub fn recv_msg(&mut self, flags: int) -> Result<Message, Error> {
+    pub fn recv(&mut self, flags: int) -> Result<Message, Error> {
         let mut msg = Message::new();
-        match self.recv(&mut msg, flags) {
+        match self.recv_into(&mut msg, flags) {
             Ok(()) => Ok(msg),
             Err(e) => Err(e),
         }
     }
 
     pub fn recv_bytes(&mut self, flags: int) -> Result<Vec<u8>, Error> {
-        match self.recv_msg(flags) {
+        match self.recv(flags) {
             Ok(msg) => Ok(msg.to_bytes()),
             Err(e) => Err(e),
         }
     }
 
     pub fn recv_str(&mut self, flags: int) -> Result<String, Error> {
-        match self.recv_msg(flags) {
+        match self.recv(flags) {
             Ok(msg) => Ok(msg.to_string()),
             Err(e) => Err(e),
         }


### PR DESCRIPTION
- send is renamed send_bytes
- a new version of send handles zmq messages

Note that I defined send as:

    pub fn send(&mut self, msg: Message, flags: int) -> Result<(), Error>

A zmq_msg is consumed by zmq once it given to zmq_send(). This maps nicely to rust by taking Message by value, which cannot be copied, only moved.

 - recv is renamed recv_into
 - recv_msg is renamed recv
 - Message::from_slice
 - a bunch of random fixes to match the latest rust
   - notably, I casted all posix88 enums to int in order to typecheck. Not sure if it is the best idea (and it looks ugly for sure)
