### PR TITLE
Updated to use .to_vec instead of .to_owned.

### DIFF
--- a/src/zmq/lib.rs
+++ b/src/zmq/lib.rs
@@ -651,7 +651,7 @@ impl Message {
     }
 
     pub fn to_bytes(&self) -> Vec<u8> {
-        self.with_bytes(|v| v.to_owned())
+        self.with_bytes(|v| v.to_vec())
     }
 
     pub fn to_string(&self) -> String {


### PR DESCRIPTION
Just a small change, but it silences a warning.
