### PR TITLE
Allow creation of poll items from file descriptor.

### DIFF
--- a/src/zmq/lib.rs
+++ b/src/zmq/lib.rs
@@ -672,6 +672,15 @@ pub struct PollItem<'a> {
 }
 
 impl<'a> PollItem<'a> {
+    pub fn from_fd(fd: c_int) -> PollItem<'a> {
+        PollItem {
+            socket: ptr::null_mut(),
+            fd: fd,
+            events: 0,
+            revents: 0
+        }
+    }
+
     pub fn get_revents(&self) -> i16 {
         self.revents
     }


### PR DESCRIPTION
Adds a constructor to PollItems to allow polling an arbitrary file descriptor. My use case was wantint to poll both stdin and a zmq socket at the same time:

``` rust
let mut items = [socket.as_poll_item(), zmq::PollItem::fd(libc::STDIN_FILENO, zmq::POLLIN)];
match zmq::poll(&mut items) {
  Ok(_) => { /*...*/ },
  Err(message) => { /*...*/ }
}
```
