### PR TITLE
Array size must be constant

### DIFF
--- a/src/zmq/lib.rs
+++ b/src/zmq/lib.rs
@@ -24,10 +24,10 @@ type Context_ = *mut c_void;
 /// A ZMQ socket
 type Socket_ = *mut c_void;
 
-static MsgSize_: uint = 48;
+const MSG_SIZE_: uint = 48;
 
 /// A message
-type Msg_ = [c_char, ..MsgSize_];
+type Msg_ = [c_char, ..MSG_SIZE_];
 
 #[link(name = "zmq")]
 extern {
@@ -347,7 +347,7 @@ impl Socket {
         unsafe {
             let base_ptr = data.as_ptr();
             let len = data.len();
-            let msg = [0, ..MsgSize_];
+            let msg = [0, ..MSG_SIZE_];
 
             // Copy the data into the message.
             let rc = zmq_msg_init_size(&msg, len as size_t);
@@ -615,7 +615,7 @@ impl Drop for Message {
 impl Message {
     pub fn new() -> Message {
         unsafe {
-            let message = Message { msg: [0, ..MsgSize_] };
+            let message = Message { msg: [0, ..MSG_SIZE_] };
             let _ = zmq_msg_init(&message.msg);
             message
         }


### PR DESCRIPTION
Switch to [const globals](https://github.com/rust-lang/rfcs/pull/246) for array sizes. Added in [PR 17853.](https://github.com/rust-lang/rust/pull/17853)

(I changed the name of the constant since it triggered the `non_uppercase_statics` style lint.)
