### PR TITLE
make rust-zmq build with nightly

### DIFF
--- a/src/zmq/lib.rs
+++ b/src/zmq/lib.rs
@@ -24,10 +24,10 @@ type Context_ = *mut c_void;
 /// A ZMQ socket
 type Socket_ = *mut c_void;
 
-static MsgSize_: uint = 48;
+const MSG_SIZE_: uint = 48;
 
 /// A message
-type Msg_ = [c_char, ..MsgSize_];
+type Msg_ = [c_char, ..MSG_SIZE_];
 
 #[link(name = "zmq")]
 extern {
@@ -347,7 +347,7 @@ impl Socket {
         unsafe {
             let base_ptr = data.as_ptr();
             let len = data.len();
-            let msg = [0, ..MsgSize_];
+            let msg = [0, ..MSG_SIZE_];
 
             // Copy the data into the message.
             let rc = zmq_msg_init_size(&msg, len as size_t);
@@ -615,7 +615,7 @@ impl Drop for Message {
 impl Message {
     pub fn new() -> Message {
         unsafe {
-            let message = Message { msg: [0, ..MsgSize_] };
+            let message = Message { msg: [0, ..MSG_SIZE_] };
             let _ = zmq_msg_init(&message.msg);
             message
         }


### PR DESCRIPTION
try to compile with today's nightly rust package and was failing with (oct 13th )

> rc/zmq/lib.rs:30:13: 30:33 error: expected constant expr for vector length: non-constant path in constant expr src/zmq/lib.rs:30 type Msg_ = [c_char, ..MsgSize_];
>                                                      ^~~~~~~~~~~~~~~~~~~~

Not sure why, I am a noob in rust, but the guide for nightly recommands using consts instead of static when needing non mutable globals. 
