### PR TITLE
Modernizing zmq-sys

### DIFF
--- a/zmq-sys/src/ffi.rs
+++ b/zmq-sys/src/ffi.rs
@@ -2,7 +2,7 @@
 
 #[repr(C)]
 pub struct Struct_zmq_msg_t {
-    pub unnamed_field1: [::libc::c_uchar, ..32u],
+    pub unnamed_field1: [::libc::c_uchar; 32],
 }
 pub type zmq_msg_t = Struct_zmq_msg_t;
 pub type zmq_free_fn = ::libc::c_void;

--- a/zmq-sys/src/lib.rs
+++ b/zmq-sys/src/lib.rs
@@ -1,3 +1,4 @@
+#![feature(libc)]
 extern crate libc;
 
 pub use ffi::{
@@ -63,5 +64,5 @@ mod ffi {
         size_t,
     };
 
-    include!("ffi.rs")
+    include!("ffi.rs");
 }


### PR DESCRIPTION
Added libc feature, fixed macros and changed array syntacticly.
zmq-sys now compiles without warnings.