### PR TITLE
destroy loop on EINTR, not EFAULT

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -129,6 +129,7 @@ pub enum Error {
     EBUSY           = posix88::EBUSY as isize,
     ECONNREFUSED    = posix88::ECONNREFUSED as isize,
     EFAULT          = posix88::EFAULT as isize,
+    EINTR           = posix88::EINTR as isize,
     EHOSTUNREACH    = posix88::EHOSTUNREACH as isize,
     EINPROGRESS     = posix88::EINPROGRESS as isize,
     EINVAL          = posix88::EINVAL as isize,
@@ -289,7 +290,7 @@ impl Drop for Context {
     fn drop(&mut self) {
         debug!("context dropped");
         let mut e = self.destroy();
-        while e == Err(Error::EFAULT) {
+        while e == Err(Error::EINTR) {
             e = self.destroy();
         }
     }


### PR DESCRIPTION
I'm pretty sure that we should be looping on `EINTR`, e.g. when a signal interrupts the call, not `EFAULT`, which [represents](http://api.zeromq.org/4-1:zmq-ctx-destroy) a faulty context, so trying it again probably won't suddenly make it a valid context. The comment on line 278 seems to reinforce this idea.

    /// Try to destroy the context. This is different than the destructor; the
    /// destructor will loop when zmq_ctx_destroy returns EINTR
