### PR TITLE
Improve API safety by giving Socket a lifetime

### DIFF
--- a/examples/zguide/helloworld_client/main.rs
+++ b/examples/zguide/helloworld_client/main.rs
@@ -7,7 +7,7 @@ extern crate zmq;
 fn main() {
     println!("Connecting to hello world server...\n");
 
-    let mut context = zmq::Context::new();
+    let context = zmq::Context::new();
     let mut requester = context.socket(zmq::REQ).unwrap();
 
     assert!(requester.connect("tcp://localhost:5555").is_ok());

--- a/examples/zguide/helloworld_server/main.rs
+++ b/examples/zguide/helloworld_server/main.rs
@@ -9,7 +9,7 @@ extern crate zmq;
 use std::thread;
 
 fn main() {
-    let mut context = zmq::Context::new();
+    let context = zmq::Context::new();
     let mut responder = context.socket(zmq::REP).unwrap();
 
     assert!(responder.bind("tcp://*:5555").is_ok());

--- a/examples/zguide/weather_client/main.rs
+++ b/examples/zguide/weather_client/main.rs
@@ -17,7 +17,7 @@ fn atoi(s: &str) -> i64 {
 fn main() {
     println!("Collecting updates from weather server...");
 
-    let mut context = zmq::Context::new();
+    let context = zmq::Context::new();
     let mut subscriber = context.socket(zmq::SUB).unwrap();
     assert!(subscriber.connect("tcp://localhost:5556").is_ok());
 

--- a/examples/zguide/weather_server/main.rs
+++ b/examples/zguide/weather_server/main.rs
@@ -10,7 +10,7 @@ extern crate zmq;
 use rand::Rng;
 
 fn main() {
-    let mut context = zmq::Context::new();
+    let context = zmq::Context::new();
     let mut publisher = context.socket(zmq::PUB).unwrap();
 
     assert!(publisher.bind("tcp://*:5556").is_ok());


### PR DESCRIPTION
Socket now has a lifetime parameter which allows the compiler ensure that
sockets last at least as long as their contexts. In order to make this
practical, Context::socket() is now &self instead of &mut self. ZMQ contexts are
already thread-safe, so this kind of aliasing should be okay.
