### PR TITLE
add parallel task examples to zguide

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 *.swp
+*~
 *.dylib
 *.dSYM
 *.o

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,6 +30,18 @@ path = "examples/zguide/weather_client/main.rs"
 name = "weather_server"
 path = "examples/zguide/weather_server/main.rs"
 
+[[example]]
+name = "taskvent"
+path = "examples/zguide/taskvent/main.rs"
+
+[[example]]
+name = "taskwork"
+path = "examples/zguide/taskwork/main.rs"
+
+[[example]]
+name = "tasksink"
+path = "examples/zguide/tasksink/main.rs"
+
 [dependencies]
 libc = "*"
 log = "*"

--- a/examples/zguide/tasksink/main.rs
+++ b/examples/zguide/tasksink/main.rs
@@ -1,0 +1,37 @@
+#![crate_name = "tasksink"]
+
+///  Task sink
+///  Binds PULL socket to tcp://localhost:5558
+///  Collects results from workers via that socket
+
+extern crate zmq;
+extern crate time;
+
+use time::PreciseTime;
+
+fn main() {
+    //  Prepare our context and socket
+    let mut context = zmq::Context::new();
+    let mut receiver = context.socket(zmq::PULL).unwrap();
+    assert!(receiver.bind("tcp://*:5558").is_ok());
+    
+    // Wait for start of batch
+    let mut msg = zmq::Message::new().unwrap();
+
+    receiver.recv(&mut msg, 0).unwrap();
+
+    //  Start our clock now
+    let start = PreciseTime::now();
+
+    for i in 1..101 {
+        receiver.recv(&mut msg, 0).unwrap();
+
+        if i % 10 == 0 {
+            print!(":");
+        } else {
+            print!(".");
+        }
+    }
+    
+    println!("\nTotal elapsed time: {} msec", start.to(PreciseTime::now()));
+}

--- a/examples/zguide/taskvent/main.rs
+++ b/examples/zguide/taskvent/main.rs
@@ -1,0 +1,46 @@
+#![crate_name = "taskvent"]
+
+///  Task ventilator
+///  Binds PUSH socket to tcp://localhost:5557
+///  Sends batch of tasks to workers via that socket
+
+extern crate zmq;
+extern crate rand;
+
+use std::io::{self,BufRead};
+use rand::Rng;
+
+fn main() {
+    let mut context = zmq::Context::new();
+
+    // Socket to send messages on
+    let mut sender = context.socket(zmq::PUSH).unwrap();
+    assert!(sender.bind("tcp://*:5557").is_ok());
+
+    //  Socket to send start of batch message on
+    let mut sink = context.socket(zmq::PUSH).unwrap();
+    assert!(sink.connect("tcp://localhost:5558").is_ok());
+
+    println!("Press Enter when the workers are ready: ");
+    let stdin = io::stdin();
+    stdin.lock().lines().next();                                                                                                                                   
+
+    println!("Sending tasks to workers . . .");
+    //  The first message is "0" and signals start of batch
+    sink.send_str("0", 0).unwrap();
+
+    let mut rng = rand::thread_rng();                                                                                                                                         
+
+    // Send 100 tasks
+    let mut total_msec: u32 = 0;
+    for _ in 0..100 {
+        //  Random workload from 1 to 100 msecs
+        let workload: u8 = rng.gen_range(1, 101);
+
+        total_msec += workload as u32;
+
+        sender.send(&[workload], 0).unwrap();
+     }
+
+    println!("Total expected cost: {} msec", total_msec)
+}

--- a/examples/zguide/taskwork/main.rs
+++ b/examples/zguide/taskwork/main.rs
@@ -1,0 +1,43 @@
+#![crate_name = "taskwork"]
+
+///  Task worker
+///  Connects PULL socket to tcp://localhost:5557
+///  Collects workloads from ventilator via that socket
+///  Connects PUSH socket to tcp://localhost:5558
+///  Sends results to sink via that socket
+
+extern crate zmq;
+
+use std::thread;
+use std::io::{self,Write};
+
+fn main() {
+    let mut context = zmq::Context::new();
+
+    // socket to receive messages on
+    let mut receiver = context.socket(zmq::PULL).unwrap();
+    assert!(receiver.connect("tcp://localhost:5557").is_ok());
+
+    //  Socket to send messages to
+    let mut sender = context.socket(zmq::PUSH).unwrap();
+    assert!(sender.connect("tcp://localhost:5558").is_ok());
+
+    let mut msg = zmq::Message::new().unwrap();
+
+    loop {
+        receiver.recv(&mut msg, 0).unwrap();
+
+        let work: u8 =  msg.as_str().unwrap().bytes().last().unwrap();
+
+        // Show progress
+        print!(".");
+        let _ = io::stdout().flush();
+
+        // Do the work
+        thread::sleep_ms(work as u32);
+
+        // Send results to sink
+        sender.send(b"",0).unwrap();
+     }
+
+}


### PR DESCRIPTION
I'm not sure what the best is to get the bytes out of a Message object (in taskwork crate). If there's something better or more efficient than msg.as_str().unwrap().bytes() I'd be happy to fix the example.