### PR TITLE
Feature socket convert

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -273,7 +273,7 @@ impl Context {
             return Err(errno_to_error());
         }
 
-        Ok(Socket::new(sock, false))
+        Ok(Socket::from_raw(sock, false))
     }
 
     /// Try to destroy the context. This is different than the destructor; the
@@ -317,12 +317,18 @@ impl Drop for Socket {
 }
 
 impl Socket {
-    pub fn new(sock: *mut libc::c_void, persistent: bool) -> Socket {
+    /// Create a socket from a raw pointer.
+    pub fn from_raw(sock: *mut libc::c_void, persistent: bool) -> Socket {
         Socket {
             sock: sock,
             closed: false,
             persistent: persistent,
         }
+    }
+
+    /// Return the raw pointer.
+    pub fn to_raw(&mut self) -> *mut libc::c_void {
+        self.sock
     }
 
     /// Accept connections on a socket.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,7 +10,7 @@ extern crate zmq_sys;
 
 use libc::{c_int, c_long, c_void, size_t, int64_t, uint64_t};
 use libc::consts::os::posix88;
-use std::{mem, ptr, str, slice};
+use std::{convert, mem, ptr, str, slice};
 use std::ffi;
 use std::fmt;
 use std::marker::PhantomData;
@@ -310,6 +310,12 @@ impl Drop for Socket {
             Ok(()) => { debug!("socket dropped") },
             Err(e) => panic!(e)
         }
+    }
+}
+
+impl convert::From<*mut libc::c_void> for Socket {
+    fn from(raw: *mut libc::c_void) -> Socket {
+        Socket { sock: raw, closed: false }
     }
 }
 


### PR DESCRIPTION
Allow Rust sockets to be constructed manually from a raw pointer, which is required when sockets are shared between external libs.

I've also included a persistent key on the Socket struct to allow other libs to continue consuming the socket after the Rust socket has gone out of scope.