### PR TITLE
Update binding to ZMQ 4.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,6 +27,7 @@ before_script:
   pip install 'travis-cargo<0.2' --user &&
   export PATH=$HOME/.local/bin:$PATH &&
   export LIBRARY_PATH=$HOME/lib &&
+  export LD_LIBRARY_PATH=$HOME/lib &&
   export PKG_CONFIG_PATH=$HOME/lib/pkgconfig &&
   wget https://download.libsodium.org/libsodium/releases/libsodium-1.0.8.tar.gz &&
   wget https://download.libsodium.org/libsodium/releases/libsodium-1.0.8.tar.gz.sig &&

--- a/.travis.yml
+++ b/.travis.yml
@@ -40,7 +40,8 @@ before_script:
   wget https://github.com/zeromq/zeromq4-1/archive/v4.1.4.tar.gz &&
   tar zxf v4.1.4.tar.gz &&
   cd zeromq4-1-4.1.4 &&
-  ./autogen.sh && ./configure --prefix=$HOME --with-libsodium && make && make install
+  ./autogen.sh && ./configure --prefix=$HOME --with-libsodium && make && make install &&
+  cd ..
 script:
 - travis-cargo build
 - travis-cargo test

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,11 +10,37 @@ addons:
     - libcurl4-openssl-dev
     - libelf-dev
     - libdw-dev
-    - libzmq3-dev
+    - make
+    - automake
+    - gcc
+    - build-essential
+    - g++
+    - cpp
+    - libc6-dev
+    - man-db
+    - autoconf
+    - pkg-config
+    - libtool
+    - git
 before_script:
 - |
   pip install 'travis-cargo<0.2' --user &&
-  export PATH=$HOME/.local/bin:$PATH
+  export PATH=$HOME/.local/bin:$PATH &&
+  export LIBRARY_PATH=$HOME/lib &&
+  export PKG_CONFIG_PATH=$HOME/lib/pkgconfig &&
+  wget https://download.libsodium.org/libsodium/releases/libsodium-1.0.8.tar.gz &&
+  wget https://download.libsodium.org/libsodium/releases/libsodium-1.0.8.tar.gz.sig &&
+  wget https://download.libsodium.org/jedi.gpg.asc &&
+  gpg --import jedi.gpg.asc &&
+  gpg --verify libsodium-1.0.8.tar.gz.sig libsodium-1.0.8.tar.gz &&
+  tar zxf libsodium-1.0.8.tar.gz &&
+  cd libsodium-1.0.8 &&
+  ./configure --prefix=$HOME && make && make install &&
+  cd .. &&
+  wget https://github.com/zeromq/zeromq4-1/archive/v4.1.4.tar.gz &&
+  tar zxf v4.1.4.tar.gz &&
+  cd zeromq4-1-4.1.4 &&
+  ./autogen.sh && ./configure --prefix=$HOME --with-libsodium && make && make install
 script:
 - travis-cargo build
 - travis-cargo test

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zmq"
-version = "0.7.0"
+version = "0.8.0"
 authors = [ "erick.tryzelaar@gmail.com" ]
 license = "MIT/Apache-2.0"
 description = "High-level bindings to the zeromq library"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,6 +5,7 @@ authors = [ "erick.tryzelaar@gmail.com" ]
 license = "MIT/Apache-2.0"
 description = "High-level bindings to the zeromq library"
 repository = "https://github.com/erickt/rust-zmq"
+build = "build.rs"
 
 [[example]]
 name = "msgsend"

--- a/build.rs
+++ b/build.rs
@@ -1,0 +1,15 @@
+use std::ffi::CString;
+use std::os::raw::{c_char, c_int};
+
+fn main() {
+	for has in ["ipc", "pgm", "tipc", "norm", "curve", "gssapi"].into_iter() {
+		if unsafe { zmq_has(CString::new(has.as_bytes()).unwrap().as_ptr()) } == 1 {
+			println!("cargo:rustc-cfg=ZMQ_HAS_{}=\"1\"", has.to_uppercase());
+		}
+	}
+}
+
+#[link(name = "zmq")]
+extern "C" {
+	fn zmq_has(capability: *const c_char) -> c_int;
+}

--- a/examples/zguide/helloworld_server/main.rs
+++ b/examples/zguide/helloworld_server/main.rs
@@ -7,6 +7,7 @@
 extern crate zmq;
 
 use std::thread;
+use std::time::Duration;
 
 fn main() {
     let mut context = zmq::Context::new();
@@ -19,6 +20,6 @@ fn main() {
         responder.recv(&mut msg, 0).unwrap();
         println!("Received {}", msg.as_str().unwrap());
         responder.send_str("World", 0).unwrap();
-        thread::sleep_ms(1000);
+        thread::sleep(Duration::from_millis(1000));
     }
 }

--- a/examples/zguide/msreader/main.rs
+++ b/examples/zguide/msreader/main.rs
@@ -5,11 +5,12 @@
 
 extern crate zmq;
 
+use std::time::Duration;
 use std::thread;
 
 fn main() {
     let mut context = zmq::Context::new();
-    
+
     // Connect to task ventilator
     let mut receiver = context.socket(zmq::PULL).unwrap();
     assert!(receiver.connect("tcp://localhost:5557").is_ok());
@@ -35,7 +36,7 @@ fn main() {
                 }
             }
         }
-        
+
         loop {
             let resp = subscriber.recv(&mut msg, zmq::DONTWAIT);
             match resp {
@@ -45,8 +46,8 @@ fn main() {
                 }
             }
         }
-        
+
         // No activity, so sleep for 1 msec
-        thread::sleep_ms(1)
+        thread::sleep(Duration::from_millis(1))
     }
 }

--- a/examples/zguide/taskwork/main.rs
+++ b/examples/zguide/taskwork/main.rs
@@ -8,8 +8,9 @@
 
 extern crate zmq;
 
-use std::thread;
 use std::io::{self,Write};
+use std::thread;
+use std::time::Duration;
 
 fn main() {
     let mut context = zmq::Context::new();
@@ -34,7 +35,7 @@ fn main() {
         let _ = io::stdout().flush();
 
         // Do the work
-        thread::sleep_ms(work as u32);
+        thread::sleep(Duration::from_millis(work as u64));
 
         // Send results to sink
         sender.send(b"",0).unwrap();

--- a/zmq-sys/Cargo.toml
+++ b/zmq-sys/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zmq-sys"
-version = "0.7.0"
+version = "0.8.0"
 authors = [ "erick.tryzelaar@gmail.com" ]
 license = "MIT/Apache-2.0"
 description = "Low-level bindings to the zeromq library"

--- a/zmq-sys/src/ffi.rs
+++ b/zmq-sys/src/ffi.rs
@@ -3,121 +3,172 @@
 #[repr(C)]
 #[derive(Copy)]
 pub struct Struct_zmq_msg_t {
-    pub unnamed_field1: [::libc::c_uchar; 64usize],
+    pub unnamed_field1: [::std::os::raw::c_uchar; 64usize],
 }
-impl Clone for Struct_zmq_msg_t {
-    fn clone(&self) -> Self {
-        *self
-    }
+impl ::std::clone::Clone for Struct_zmq_msg_t {
+    fn clone(&self) -> Self { *self }
+}
+impl ::std::default::Default for Struct_zmq_msg_t {
+    fn default() -> Self { unsafe { ::std::mem::zeroed() } }
 }
 pub type zmq_msg_t = Struct_zmq_msg_t;
-pub type zmq_free_fn = ::libc::c_void;
+pub type zmq_free_fn =
+    unsafe extern "C" fn(data: *mut ::std::os::raw::c_void,
+                         hint: *mut ::std::os::raw::c_void);
 #[repr(C)]
-#[derive(Clone, Copy)]
-pub struct Struct_Unnamed1 {
-    pub event: uint16_t,
-    pub value: int32_t,
+#[derive(Copy)]
+pub struct Struct_zmq_pollitem_t {
+    pub socket: *mut ::std::os::raw::c_void,
+    pub fd: ::std::os::raw::c_int,
+    pub events: ::std::os::raw::c_short,
+    pub revents: ::std::os::raw::c_short,
 }
-pub type zmq_event_t = Struct_Unnamed1;
+impl ::std::clone::Clone for Struct_zmq_pollitem_t {
+    fn clone(&self) -> Self { *self }
+}
+impl ::std::default::Default for Struct_zmq_pollitem_t {
+    fn default() -> Self { unsafe { ::std::mem::zeroed() } }
+}
+pub type zmq_pollitem_t = Struct_zmq_pollitem_t;
 pub enum Struct_iovec { }
-#[repr(C)]
-#[derive(Clone, Copy)]
-#[allow(raw_pointer_derive)]
-pub struct Struct_Unnamed2 {
-    pub socket: *mut ::libc::c_void,
-    pub fd: ::libc::c_int,
-    pub events: ::libc::c_short,
-    pub revents: ::libc::c_short,
-}
-pub type zmq_pollitem_t = Struct_Unnamed2;
-#[link(name = "zmq")]
-extern "C" { }
+pub type zmq_thread_fn =
+    unsafe extern "C" fn(arg1: *mut ::std::os::raw::c_void);
 #[link(name = "zmq")]
 extern "C" {
-    pub fn zmq_version(major: *mut ::libc::c_int, minor: *mut ::libc::c_int,
-                       patch: *mut ::libc::c_int);
-    pub fn zmq_errno() -> ::libc::c_int;
-    pub fn zmq_strerror(errnum: ::libc::c_int) -> *const ::libc::c_char;
-    pub fn zmq_ctx_new() -> *mut ::libc::c_void;
-    pub fn zmq_ctx_term(context: *mut ::libc::c_void) -> ::libc::c_int;
-    pub fn zmq_ctx_shutdown(ctx_: *mut ::libc::c_void) -> ::libc::c_int;
-    pub fn zmq_ctx_set(context: *mut ::libc::c_void, option: ::libc::c_int,
-                       optval: ::libc::c_int) -> ::libc::c_int;
-    pub fn zmq_ctx_get(context: *mut ::libc::c_void, option: ::libc::c_int)
-     -> ::libc::c_int;
-    pub fn zmq_init(io_threads: ::libc::c_int) -> *mut ::libc::c_void;
-    pub fn zmq_term(context: *mut ::libc::c_void) -> ::libc::c_int;
-    pub fn zmq_ctx_destroy(context: *mut ::libc::c_void) -> ::libc::c_int;
-    pub fn zmq_msg_init(msg: *mut zmq_msg_t) -> ::libc::c_int;
+    pub fn zmq_errno() -> ::std::os::raw::c_int;
+    pub fn zmq_strerror(errnum: ::std::os::raw::c_int)
+     -> *const ::std::os::raw::c_char;
+    pub fn zmq_version(major: *mut ::std::os::raw::c_int,
+                       minor: *mut ::std::os::raw::c_int,
+                       patch: *mut ::std::os::raw::c_int);
+    pub fn zmq_ctx_new() -> *mut ::std::os::raw::c_void;
+    pub fn zmq_ctx_term(context: *mut ::std::os::raw::c_void)
+     -> ::std::os::raw::c_int;
+    pub fn zmq_ctx_shutdown(ctx_: *mut ::std::os::raw::c_void)
+     -> ::std::os::raw::c_int;
+    pub fn zmq_ctx_set(context: *mut ::std::os::raw::c_void,
+                       option: ::std::os::raw::c_int,
+                       optval: ::std::os::raw::c_int)
+     -> ::std::os::raw::c_int;
+    pub fn zmq_ctx_get(context: *mut ::std::os::raw::c_void,
+                       option: ::std::os::raw::c_int)
+     -> ::std::os::raw::c_int;
+    pub fn zmq_init(io_threads: ::std::os::raw::c_int)
+     -> *mut ::std::os::raw::c_void;
+    pub fn zmq_term(context: *mut ::std::os::raw::c_void)
+     -> ::std::os::raw::c_int;
+    pub fn zmq_ctx_destroy(context: *mut ::std::os::raw::c_void)
+     -> ::std::os::raw::c_int;
+    pub fn zmq_msg_init(msg: *mut zmq_msg_t) -> ::std::os::raw::c_int;
     pub fn zmq_msg_init_size(msg: *mut zmq_msg_t, size: size_t)
-     -> ::libc::c_int;
-    pub fn zmq_msg_init_data(msg: *mut zmq_msg_t, data: *mut ::libc::c_void,
-                             size: size_t, ffn: *mut zmq_free_fn,
-                             hint: *mut ::libc::c_void) -> ::libc::c_int;
-    pub fn zmq_msg_send(msg: *mut zmq_msg_t, s: *mut ::libc::c_void,
-                        flags: ::libc::c_int) -> ::libc::c_int;
-    pub fn zmq_msg_recv(msg: *mut zmq_msg_t, s: *mut ::libc::c_void,
-                        flags: ::libc::c_int) -> ::libc::c_int;
-    pub fn zmq_msg_close(msg: *mut zmq_msg_t) -> ::libc::c_int;
+     -> ::std::os::raw::c_int;
+    pub fn zmq_msg_init_data(msg: *mut zmq_msg_t,
+                             data: *mut ::std::os::raw::c_void, size: size_t,
+                             ffn: *mut zmq_free_fn,
+                             hint: *mut ::std::os::raw::c_void)
+     -> ::std::os::raw::c_int;
+    pub fn zmq_msg_send(msg: *mut zmq_msg_t, s: *mut ::std::os::raw::c_void,
+                        flags: ::std::os::raw::c_int)
+     -> ::std::os::raw::c_int;
+    pub fn zmq_msg_recv(msg: *mut zmq_msg_t, s: *mut ::std::os::raw::c_void,
+                        flags: ::std::os::raw::c_int)
+     -> ::std::os::raw::c_int;
+    pub fn zmq_msg_close(msg: *mut zmq_msg_t) -> ::std::os::raw::c_int;
     pub fn zmq_msg_move(dest: *mut zmq_msg_t, src: *mut zmq_msg_t)
-     -> ::libc::c_int;
+     -> ::std::os::raw::c_int;
     pub fn zmq_msg_copy(dest: *mut zmq_msg_t, src: *mut zmq_msg_t)
-     -> ::libc::c_int;
-    pub fn zmq_msg_data(msg: *mut zmq_msg_t) -> *mut ::libc::c_void;
+     -> ::std::os::raw::c_int;
+    pub fn zmq_msg_data(msg: *mut zmq_msg_t) -> *mut ::std::os::raw::c_void;
     pub fn zmq_msg_size(msg: *mut zmq_msg_t) -> size_t;
-    pub fn zmq_msg_more(msg: *mut zmq_msg_t) -> ::libc::c_int;
-    pub fn zmq_msg_get(msg: *mut zmq_msg_t, option: ::libc::c_int)
-     -> ::libc::c_int;
-    pub fn zmq_msg_set(msg: *mut zmq_msg_t, option: ::libc::c_int,
-                       optval: ::libc::c_int) -> ::libc::c_int;
-    pub fn zmq_socket(arg1: *mut ::libc::c_void, _type: ::libc::c_int)
-     -> *mut ::libc::c_void;
-    pub fn zmq_close(s: *mut ::libc::c_void) -> ::libc::c_int;
-    pub fn zmq_setsockopt(s: *mut ::libc::c_void, option: ::libc::c_int,
-                          optval: *const ::libc::c_void, optvallen: size_t)
-     -> ::libc::c_int;
-    pub fn zmq_getsockopt(s: *mut ::libc::c_void, option: ::libc::c_int,
-                          optval: *mut ::libc::c_void, optvallen: *mut size_t)
-     -> ::libc::c_int;
-    pub fn zmq_bind(s: *mut ::libc::c_void, addr: *const ::libc::c_char)
-     -> ::libc::c_int;
-    pub fn zmq_connect(s: *mut ::libc::c_void, addr: *const ::libc::c_char)
-     -> ::libc::c_int;
-    pub fn zmq_unbind(s: *mut ::libc::c_void, addr: *const ::libc::c_char)
-     -> ::libc::c_int;
-    pub fn zmq_disconnect(s: *mut ::libc::c_void, addr: *const ::libc::c_char)
-     -> ::libc::c_int;
-    pub fn zmq_send(s: *mut ::libc::c_void, buf: *const ::libc::c_void,
-                    len: size_t, flags: ::libc::c_int) -> ::libc::c_int;
-    pub fn zmq_send_const(s: *mut ::libc::c_void, buf: *const ::libc::c_void,
-                          len: size_t, flags: ::libc::c_int) -> ::libc::c_int;
-    pub fn zmq_recv(s: *mut ::libc::c_void, buf: *mut ::libc::c_void,
-                    len: size_t, flags: ::libc::c_int) -> ::libc::c_int;
-    pub fn zmq_socket_monitor(s: *mut ::libc::c_void,
-                              addr: *const ::libc::c_char,
-                              events: ::libc::c_int) -> ::libc::c_int;
-    pub fn zmq_sendmsg(s: *mut ::libc::c_void, msg: *mut zmq_msg_t,
-                       flags: ::libc::c_int) -> ::libc::c_int;
-    pub fn zmq_recvmsg(s: *mut ::libc::c_void, msg: *mut zmq_msg_t,
-                       flags: ::libc::c_int) -> ::libc::c_int;
-    pub fn zmq_sendiov(s: *mut ::libc::c_void, iov: *mut Struct_iovec,
-                       count: size_t, flags: ::libc::c_int) -> ::libc::c_int;
-    pub fn zmq_recviov(s: *mut ::libc::c_void, iov: *mut Struct_iovec,
-                       count: *mut size_t, flags: ::libc::c_int)
-     -> ::libc::c_int;
-    pub fn zmq_poll(items: *mut zmq_pollitem_t, nitems: ::libc::c_int,
-                    timeout: ::libc::c_long) -> ::libc::c_int;
-    pub fn zmq_proxy(frontend: *mut ::libc::c_void,
-                     backend: *mut ::libc::c_void,
-                     capture: *mut ::libc::c_void) -> ::libc::c_int;
-    pub fn zmq_proxy_steerable(frontend: *mut ::libc::c_void,
-                               backend: *mut ::libc::c_void,
-                               capture: *mut ::libc::c_void,
-                               control: *mut ::libc::c_void) -> ::libc::c_int;
-    pub fn zmq_z85_encode(dest: *mut ::libc::c_char, data: *mut uint8_t,
-                          size: size_t) -> *mut ::libc::c_char;
-    pub fn zmq_z85_decode(dest: *mut uint8_t, string: *mut ::libc::c_char)
+    pub fn zmq_msg_more(msg: *mut zmq_msg_t) -> ::std::os::raw::c_int;
+    pub fn zmq_msg_get(msg: *mut zmq_msg_t, property: ::std::os::raw::c_int)
+     -> ::std::os::raw::c_int;
+    pub fn zmq_msg_set(msg: *mut zmq_msg_t, property: ::std::os::raw::c_int,
+                       optval: ::std::os::raw::c_int)
+     -> ::std::os::raw::c_int;
+    pub fn zmq_msg_gets(msg: *mut zmq_msg_t,
+                        property: *const ::std::os::raw::c_char)
+     -> *const ::std::os::raw::c_char;
+    pub fn zmq_socket(arg1: *mut ::std::os::raw::c_void,
+                      _type: ::std::os::raw::c_int)
+     -> *mut ::std::os::raw::c_void;
+    pub fn zmq_close(s: *mut ::std::os::raw::c_void) -> ::std::os::raw::c_int;
+    pub fn zmq_setsockopt(s: *mut ::std::os::raw::c_void,
+                          option: ::std::os::raw::c_int,
+                          optval: *const ::std::os::raw::c_void,
+                          optvallen: size_t) -> ::std::os::raw::c_int;
+    pub fn zmq_getsockopt(s: *mut ::std::os::raw::c_void,
+                          option: ::std::os::raw::c_int,
+                          optval: *mut ::std::os::raw::c_void,
+                          optvallen: *mut size_t) -> ::std::os::raw::c_int;
+    pub fn zmq_bind(s: *mut ::std::os::raw::c_void,
+                    addr: *const ::std::os::raw::c_char)
+     -> ::std::os::raw::c_int;
+    pub fn zmq_connect(s: *mut ::std::os::raw::c_void,
+                       addr: *const ::std::os::raw::c_char)
+     -> ::std::os::raw::c_int;
+    pub fn zmq_unbind(s: *mut ::std::os::raw::c_void,
+                      addr: *const ::std::os::raw::c_char)
+     -> ::std::os::raw::c_int;
+    pub fn zmq_disconnect(s: *mut ::std::os::raw::c_void,
+                          addr: *const ::std::os::raw::c_char)
+     -> ::std::os::raw::c_int;
+    pub fn zmq_send(s: *mut ::std::os::raw::c_void,
+                    buf: *const ::std::os::raw::c_void, len: size_t,
+                    flags: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
+    pub fn zmq_send_const(s: *mut ::std::os::raw::c_void,
+                          buf: *const ::std::os::raw::c_void, len: size_t,
+                          flags: ::std::os::raw::c_int)
+     -> ::std::os::raw::c_int;
+    pub fn zmq_recv(s: *mut ::std::os::raw::c_void,
+                    buf: *mut ::std::os::raw::c_void, len: size_t,
+                    flags: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
+    pub fn zmq_socket_monitor(s: *mut ::std::os::raw::c_void,
+                              addr: *const ::std::os::raw::c_char,
+                              events: ::std::os::raw::c_int)
+     -> ::std::os::raw::c_int;
+    pub fn zmq_poll(items: *mut zmq_pollitem_t, nitems: ::std::os::raw::c_int,
+                    timeout: ::std::os::raw::c_long) -> ::std::os::raw::c_int;
+    pub fn zmq_proxy(frontend: *mut ::std::os::raw::c_void,
+                     backend: *mut ::std::os::raw::c_void,
+                     capture: *mut ::std::os::raw::c_void)
+     -> ::std::os::raw::c_int;
+    pub fn zmq_proxy_steerable(frontend: *mut ::std::os::raw::c_void,
+                               backend: *mut ::std::os::raw::c_void,
+                               capture: *mut ::std::os::raw::c_void,
+                               control: *mut ::std::os::raw::c_void)
+     -> ::std::os::raw::c_int;
+    pub fn zmq_has(capability: *const ::std::os::raw::c_char)
+     -> ::std::os::raw::c_int;
+    pub fn zmq_device(_type: ::std::os::raw::c_int,
+                      frontend: *mut ::std::os::raw::c_void,
+                      backend: *mut ::std::os::raw::c_void)
+     -> ::std::os::raw::c_int;
+    pub fn zmq_sendmsg(s: *mut ::std::os::raw::c_void, msg: *mut zmq_msg_t,
+                       flags: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
+    pub fn zmq_recvmsg(s: *mut ::std::os::raw::c_void, msg: *mut zmq_msg_t,
+                       flags: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
+    pub fn zmq_z85_encode(dest: *mut ::std::os::raw::c_char,
+                          data: *const uint8_t, size: size_t)
+     -> *mut ::std::os::raw::c_char;
+    pub fn zmq_z85_decode(dest: *mut uint8_t,
+                          string: *const ::std::os::raw::c_char)
      -> *mut uint8_t;
-    pub fn zmq_device(_type: ::libc::c_int, frontend: *mut ::libc::c_void,
-                      backend: *mut ::libc::c_void) -> ::libc::c_int;
+    pub fn zmq_curve_keypair(z85_public_key: *mut ::std::os::raw::c_char,
+                             z85_secret_key: *mut ::std::os::raw::c_char)
+     -> ::std::os::raw::c_int;
+    pub fn zmq_sendiov(s: *mut ::std::os::raw::c_void, iov: *mut Struct_iovec,
+                       count: size_t, flags: ::std::os::raw::c_int)
+     -> ::std::os::raw::c_int;
+    pub fn zmq_recviov(s: *mut ::std::os::raw::c_void, iov: *mut Struct_iovec,
+                       count: *mut size_t, flags: ::std::os::raw::c_int)
+     -> ::std::os::raw::c_int;
+    pub fn zmq_stopwatch_start() -> *mut ::std::os::raw::c_void;
+    pub fn zmq_stopwatch_stop(watch_: *mut ::std::os::raw::c_void)
+     -> ::std::os::raw::c_ulong;
+    pub fn zmq_sleep(seconds_: ::std::os::raw::c_int);
+    pub fn zmq_threadstart(func: *mut zmq_thread_fn,
+                           arg: *mut ::std::os::raw::c_void)
+     -> *mut ::std::os::raw::c_void;
+    pub fn zmq_threadclose(thread: *mut ::std::os::raw::c_void);
 }

--- a/zmq-sys/src/lib.rs
+++ b/zmq-sys/src/lib.rs
@@ -4,9 +4,7 @@ extern crate libc;
 pub use ffi::{
     zmq_msg_t,
     zmq_free_fn,
-    zmq_event_t,
     zmq_pollitem_t,
-
     zmq_version,
     zmq_errno,
     zmq_strerror,
@@ -31,6 +29,7 @@ pub use ffi::{
     zmq_msg_more,
     zmq_msg_get,
     zmq_msg_set,
+    zmq_msg_gets,
     zmq_socket,
     zmq_close,
     zmq_setsockopt,
@@ -50,17 +49,22 @@ pub use ffi::{
     zmq_poll,
     zmq_proxy,
     zmq_proxy_steerable,
+    zmq_has,
+    zmq_device,
     zmq_z85_encode,
     zmq_z85_decode,
-    zmq_device,
+    zmq_curve_keypair,
+    zmq_stopwatch_start,
+    zmq_stopwatch_stop,
+    zmq_sleep,
+    zmq_threadstart,
+    zmq_threadclose,
 };
 
 #[allow(non_camel_case_types)]
 mod ffi {
     use libc::{
         uint8_t,
-        uint16_t,
-        int32_t,
         size_t,
     };
 


### PR DESCRIPTION
This is a bit of a big change, but it brings the binding up-to-date with ZeroMQ 4.1, including auth mechanisms (Plain, Curve, GSSAPI) etc. If it's in the C lib, you should now be able to do it with Rust.

Note: Some fns have been removed or their signatures changed to bring the library into compliance with ZMQ4.1.

Feedback most welcome! I am still a Rust rookie.