### PR TITLE
Add some convenience methods

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -583,6 +583,10 @@ impl Socket {
             marker: PhantomData
         }
     }
+
+    pub fn poll(&self, events: i16, timeout_ms: i64) -> Result<i32, Error> {
+        poll(&mut [self.as_poll_item(events)], timeout_ms)
+    }
 }
 
 const MSG_SIZE: usize = 64;
@@ -757,7 +761,7 @@ impl fmt::Debug for Error {
 
 macro_rules! getsockopt_num(
     ($name:ident, $c_ty:ty, $ty:ty) => (
-        #[allow(trivial_casts)]    
+        #[allow(trivial_casts)]
         fn $name(sock: *mut libc::c_void, opt: c_int) -> Result<$ty, Error> {
             unsafe {
                 let mut value: $c_ty = 0;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -378,6 +378,20 @@ impl Socket {
         }
     }
 
+    // Receive bytes into a slice. The length passed to zmq_recv is the length of the slice.
+    pub fn recv_into(&mut self, bytes: &mut [u8], flags: i32) -> Result<(), Error> {
+        let rc = unsafe {
+            let bytes_ptr = bytes.as_mut_ptr() as *mut c_void;
+            zmq_sys::zmq_recv(self.sock, bytes_ptr, bytes.len(), flags as c_int)
+        };
+
+        if rc == -1i32 {
+            Err(errno_to_error())
+        } else {
+            Ok(())
+        }
+    }
+
     pub fn recv_msg(&mut self, flags: i32) -> Result<Message, Error> {
         let mut msg = try!(Message::new());
         match self.recv(&mut msg, flags) {


### PR DESCRIPTION
Specifically: socket.recv_multipart(), socket.send_multipart(), and socket.poll().

The logic for these functions is copied from the python zeromq bindings:

send_multipart: https://github.com/zeromq/pyzmq/blob/master/zmq/sugar/socket.py#L326
recv_multipart: https://github.com/zeromq/pyzmq/blob/master/zmq/sugar/socket.py#L370
poll: https://github.com/zeromq/pyzmq/blob/master/zmq/sugar/socket.py#L513