### PR TITLE
add build script which allows setting libzmq prefix

### DIFF
--- a/zmq-sys/Cargo.toml
+++ b/zmq-sys/Cargo.toml
@@ -5,6 +5,11 @@ authors = [ "erick.tryzelaar@gmail.com" ]
 license = "MIT/Apache-2.0"
 description = "Low-level bindings to the zeromq library"
 repository = "https://github.com/erickt/rust-zmq"
+build = "build.rs"
+links = "libzmq"
 
 [dependencies]
 libc = "0.2.*"
+
+[build-dependencies]
+pkg-config = "0.3"

--- a/zmq-sys/build.rs
+++ b/zmq-sys/build.rs
@@ -1,0 +1,15 @@
+extern crate pkg_config;
+
+use std::env;
+
+fn main() {
+    if let Some(prefix) = env::var("LIBZMQ_PREFIX").ok() {
+        println!("cargo:rustc-link-search=native={}/lib", prefix);
+        println!("cargo:include={}/include", prefix);
+    } else {
+        match pkg_config::find_library("libzmq") {
+            Ok(pkg) => println!("{:?}", pkg),
+            Err(e) => panic!("Unable to locate libzmq, err={:?}", e),
+        }
+    }
+}


### PR DESCRIPTION
This PR allows for setting the prefix of the libzmq directory at compile time. If the prefix is not provided then we fallback to pkg-config to identify the best possible place