### PR TITLE
Raw socket interface

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -428,7 +428,7 @@ impl Socket {
     /// **WARNING**
     /// It is your responsibility to make sure that the underlying
     /// memory is not freed too early.
-    pub fn as_mut_ptr(&self) -> *mut c_void {
+    pub fn as_mut_ptr(&mut self) -> *mut c_void {
         self.sock
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -552,11 +552,6 @@ impl Socket {
         Ok(parts)
     }
 
-    #[deprecated(note="`close` is handled implicitly by the Drop trait")]
-    pub fn close(self) -> Result<()> {
-        Ok(())
-    }
-
     pub fn is_ipv6(&self) -> Result<bool> {
         Ok(try!(getsockopt_i32(self.sock, Constants::ZMQ_IPV6.to_raw())) == 1)
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -552,11 +552,8 @@ impl Socket {
         Ok(parts)
     }
 
+    #[deprecated(note="`close` is handled implicitly by the Drop trait")]
     pub fn close(self) -> Result<()> {
-        if self.owned && unsafe { zmq_sys::zmq_close(self.sock) } == -1i32 {
-            return Err(errno_to_error());
-        }
-
         Ok(())
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -352,7 +352,10 @@ impl Context {
             return Err(errno_to_error());
         }
 
-        Ok(Socket::from_raw(sock))
+        Ok(Socket {
+            sock: sock,
+            owned: true,
+        })
     }
 
     /// Try to destroy the context. This is different than the destructor; the
@@ -414,7 +417,7 @@ impl Socket {
     /// Create a Socket from a raw socket pointer. The Socket assumes
     /// ownership of the pointer and will close the socket when it is
     /// dropped.
-    pub fn from_raw(sock: *mut c_void) -> Socket {
+    pub unsafe fn from_raw(sock: *mut c_void) -> Socket {
         Socket {
             sock: sock,
             owned: true,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -424,10 +424,11 @@ impl Socket {
         }
     }
 
-    /// Borrow the raw socket pointer without disabling destructor.
-    /// If the Socket goes out of scope, this will lead to a dangling
-    /// pointer, so use with care!
-    pub fn borrow_raw(&self) -> *mut c_void {
+    /// Returns the inner pointer to this Socket.
+    /// **WARNING**
+    /// It is your responsibility to make sure that the underlying
+    /// memory is not freed too early.
+    pub fn as_mut_ptr(&self) -> *mut c_void {
         self.sock
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -406,7 +406,7 @@ impl Socket {
     ///
     /// Failure to close the raw socket manually or call `from_raw`
     /// will lead to a memory leak.
-    pub fn to_raw(mut self) -> *mut c_void {
+    pub fn into_raw(mut self) -> *mut c_void {
         self.owned = false;
         self.sock
     }


### PR DESCRIPTION
Need these methods (to/from/borrow_raw) for passing Sockets to CZMQ structs (ZPoller etc.).

I've also changed the semantics of closing a socket - If we're closing the socket, it makes sense to destroy it, and if we're going to destroy it, we may as well just handle it implicitly. What do you think?