### PR TITLE
Support for Windows (Updated)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -58,5 +58,8 @@ zmq-sys = { version = "0.8.0", path = "zmq-sys" }
 compiletest_rs = { version = "0.*", optional = true }
 clippy = { version = "0.*", optional = true }
 
+[build-dependencies]
+zmq-sys = { version = "0.8.0", path = "zmq-sys" }
+
 [dev-dependencies]
 rand = "*"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,6 +48,8 @@ name = "weather_server"
 path = "examples/zguide/weather_server/main.rs"
 
 [features]
+default = ["zmq_has"]
+zmq_has = []
 unstable = ["clippy"]
 unstable-testing = ["compiletest_rs", "unstable"]
 

--- a/build.rs
+++ b/build.rs
@@ -1,6 +1,7 @@
 use std::ffi::CString;
 use std::os::raw::{c_char, c_int};
 
+#[cfg(feature = "zmq_has")]
 fn main() {
 	for has in ["ipc", "pgm", "tipc", "norm", "curve", "gssapi"].into_iter() {
 		if unsafe { zmq_has(CString::new(has.as_bytes()).unwrap().as_ptr()) } == 1 {
@@ -9,6 +10,12 @@ fn main() {
 	}
 }
 
+#[cfg(not(feature = "zmq_has"))]
+fn main() {
+	
+}
+
+#[cfg(feature = "zmq_has")]
 #[link(name = "zmq")]
 extern "C" {
 	fn zmq_has(capability: *const c_char) -> c_int;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -267,7 +267,6 @@ impl Error {
             errno::ENOBUFS            => Error::ENOBUFS,
             errno::ENETDOWN           => Error::ENETDOWN,
             errno::EADDRNOTAVAIL      => Error::EADDRNOTAVAIL,
-            156384713                => Error::ENOTSUP,
             156384714                => Error::EPROTONOSUPPORT,
             156384715                => Error::ENOBUFS,
             156384716                => Error::ENETDOWN,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1223,7 +1223,7 @@ pub fn z85_encode(data: &[u8]) -> result::Result<String, EncodeError> {
         return Err(EncodeError::BadLength);
     }
 
-    let len = data.len() * 5 / 4;
+    let len = data.len() * 5 / 4 + 1;
     let mut dest = vec![0u8; len];
 
     unsafe {
@@ -1233,6 +1233,7 @@ pub fn z85_encode(data: &[u8]) -> result::Result<String, EncodeError> {
             data.len());
     }
 
+    dest.truncate(len-1);
     String::from_utf8(dest).map_err(EncodeError::FromUtf8Error)
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -20,6 +20,7 @@ use std::os::raw::c_void;
 use std::result;
 use std::string::FromUtf8Error;
 use std::{mem, ptr, str, slice};
+use zmq_sys::errno;
 
 pub use SocketType::*;
 
@@ -198,40 +199,39 @@ pub enum Mechanism {
 
 impl Copy for Mechanism {}
 
-const ZMQ_HAUSNUMERO: isize = 156384712;
 
 #[derive(Clone, Eq, PartialEq)]
 pub enum Error {
-    EACCES          = libc::EACCES as isize,
-    EADDRINUSE      = libc::EADDRINUSE as isize,
-    EAGAIN          = libc::EAGAIN as isize,
-    EBUSY           = libc::EBUSY as isize,
-    ECONNREFUSED    = libc::ECONNREFUSED as isize,
-    EFAULT          = libc::EFAULT as isize,
-    EINTR           = libc::EINTR as isize,
-    EHOSTUNREACH    = libc::EHOSTUNREACH as isize,
-    EINPROGRESS     = libc::EINPROGRESS as isize,
-    EINVAL          = libc::EINVAL as isize,
-    EMFILE          = libc::EMFILE as isize,
-    EMSGSIZE        = libc::EMSGSIZE as isize,
-    ENAMETOOLONG    = libc::ENAMETOOLONG as isize,
-    ENODEV          = libc::ENODEV as isize,
-    ENOENT          = libc::ENOENT as isize,
-    ENOMEM          = libc::ENOMEM as isize,
-    ENOTCONN        = libc::ENOTCONN as isize,
-    ENOTSOCK        = libc::ENOTSOCK as isize,
-    EPROTO          = libc::EPROTO as isize,
-    EPROTONOSUPPORT = libc::EPROTONOSUPPORT as isize,
-    ENOTSUP         = (ZMQ_HAUSNUMERO + 1) as isize,
-    ENOBUFS         = (ZMQ_HAUSNUMERO + 3) as isize,
-    ENETDOWN        = (ZMQ_HAUSNUMERO + 4) as isize,
-    EADDRNOTAVAIL   = (ZMQ_HAUSNUMERO + 6) as isize,
+    EACCES          = errno::EACCES as isize,
+    EADDRINUSE      = errno::EADDRINUSE as isize,
+    EAGAIN          = errno::EAGAIN as isize,
+    EBUSY           = errno::EBUSY as isize,
+    ECONNREFUSED    = errno::ECONNREFUSED as isize,
+    EFAULT          = errno::EFAULT as isize,
+    EINTR           = errno::EINTR as isize,
+    EHOSTUNREACH    = errno::EHOSTUNREACH as isize,
+    EINPROGRESS     = errno::EINPROGRESS as isize,
+    EINVAL          = errno::EINVAL as isize,
+    EMFILE          = errno::EMFILE as isize,
+    EMSGSIZE        = errno::EMSGSIZE as isize,
+    ENAMETOOLONG    = errno::ENAMETOOLONG as isize,
+    ENODEV          = errno::ENODEV as isize,
+    ENOENT          = errno::ENOENT as isize,
+    ENOMEM          = errno::ENOMEM as isize,
+    ENOTCONN        = errno::ENOTCONN as isize,
+    ENOTSOCK        = errno::ENOTSOCK as isize,
+    EPROTO          = errno::EPROTO as isize,
+    EPROTONOSUPPORT = errno::EPROTONOSUPPORT as isize,
+    ENOTSUP         = errno::ENOTSUP as isize,
+    ENOBUFS         = errno::ENOBUFS as isize,
+    ENETDOWN        = errno::ENETDOWN as isize,
+    EADDRNOTAVAIL   = errno::EADDRNOTAVAIL as isize,
 
     // native zmq error codes
-    EFSM            = (ZMQ_HAUSNUMERO + 51) as isize,
-    ENOCOMPATPROTO  = (ZMQ_HAUSNUMERO + 52) as isize,
-    ETERM           = (ZMQ_HAUSNUMERO + 53) as isize,
-    EMTHREAD        = (ZMQ_HAUSNUMERO + 54) as isize,
+    EFSM            = errno::EFSM as isize,
+    ENOCOMPATPROTO  = errno::ENOCOMPATPROTO as isize,
+    ETERM           = errno::ETERM as isize,
+    EMTHREAD        = errno::EMTHREAD as isize,
 }
 
 impl Copy for Error {}
@@ -244,25 +244,29 @@ impl Error {
     pub fn from_raw(raw: i32) -> Error {
         #![cfg_attr(feature = "clippy", allow(match_same_arms))]
         match raw {
-            libc::EACCES             => Error::EACCES,
-            libc::EADDRINUSE         => Error::EADDRINUSE,
-            libc::EAGAIN             => Error::EAGAIN,
-            libc::EBUSY              => Error::EBUSY,
-            libc::ECONNREFUSED       => Error::ECONNREFUSED,
-            libc::EFAULT             => Error::EFAULT,
-            libc::EHOSTUNREACH       => Error::EHOSTUNREACH,
-            libc::EINPROGRESS        => Error::EINPROGRESS,
-            libc::EINVAL             => Error::EINVAL,
-            libc::EMFILE             => Error::EMFILE,
-            libc::EMSGSIZE           => Error::EMSGSIZE,
-            libc::ENAMETOOLONG       => Error::ENAMETOOLONG,
-            libc::ENODEV             => Error::ENODEV,
-            libc::ENOENT             => Error::ENOENT,
-            libc::ENOMEM             => Error::ENOMEM,
-            libc::ENOTCONN           => Error::ENOTCONN,
-            libc::ENOTSOCK           => Error::ENOTSOCK,
-            libc::EPROTO             => Error::EPROTO,
-            libc::EPROTONOSUPPORT    => Error::EPROTONOSUPPORT,
+            errno::EACCES             => Error::EACCES,
+            errno::EADDRINUSE         => Error::EADDRINUSE,
+            errno::EAGAIN             => Error::EAGAIN,
+            errno::EBUSY              => Error::EBUSY,
+            errno::ECONNREFUSED       => Error::ECONNREFUSED,
+            errno::EFAULT             => Error::EFAULT,
+            errno::EHOSTUNREACH       => Error::EHOSTUNREACH,
+            errno::EINPROGRESS        => Error::EINPROGRESS,
+            errno::EINVAL             => Error::EINVAL,
+            errno::EMFILE             => Error::EMFILE,
+            errno::EMSGSIZE           => Error::EMSGSIZE,
+            errno::ENAMETOOLONG       => Error::ENAMETOOLONG,
+            errno::ENODEV             => Error::ENODEV,
+            errno::ENOENT             => Error::ENOENT,
+            errno::ENOMEM             => Error::ENOMEM,
+            errno::ENOTCONN           => Error::ENOTCONN,
+            errno::ENOTSOCK           => Error::ENOTSOCK,
+            errno::EPROTO             => Error::EPROTO,
+            errno::EPROTONOSUPPORT    => Error::EPROTONOSUPPORT,
+            errno::ENOTSUP            => Error::ENOTSUP,
+            errno::ENOBUFS            => Error::ENOBUFS,
+            errno::ENETDOWN           => Error::ENETDOWN,
+            errno::EADDRNOTAVAIL      => Error::EADDRNOTAVAIL,
             156384713                => Error::ENOTSUP,
             156384714                => Error::EPROTONOSUPPORT,
             156384715                => Error::ENOBUFS,

--- a/zmq-sys/Cargo.toml
+++ b/zmq-sys/Cargo.toml
@@ -6,7 +6,7 @@ license = "MIT/Apache-2.0"
 description = "Low-level bindings to the zeromq library"
 repository = "https://github.com/erickt/rust-zmq"
 build = "build.rs"
-links = "libzmq"
+links = "zmq"
 
 [dependencies]
 libc = "0.2.15"

--- a/zmq-sys/build.rs
+++ b/zmq-sys/build.rs
@@ -7,7 +7,7 @@ fn main() {
         println!("cargo:rustc-link-search=native={}/lib", prefix);
         println!("cargo:include={}/include", prefix);
     } else {
-        match pkg_config::find_library("libzmq") {
+        match pkg_config::probe_library("libzmq") {
             Ok(pkg) => println!("{:?}", pkg),
             Err(e) => panic!("Unable to locate libzmq, err={:?}", e),
         }

--- a/zmq-sys/src/errno.rs
+++ b/zmq-sys/src/errno.rs
@@ -3,7 +3,7 @@
 use win_errno as errno;
 
 #[cfg(not(target_os = "windows"))]
-use nix_errno as errno; 
+use libc as errno;
 
 const ZMQ_HAUSNUMERO: i32 = 156384712;
 

--- a/zmq-sys/src/errno.rs
+++ b/zmq-sys/src/errno.rs
@@ -1,0 +1,44 @@
+
+#[cfg(target_os = "windows")]
+use win_errno as errno;
+
+#[cfg(not(target_os = "windows"))]
+use nix_errno as errno; 
+
+const ZMQ_HAUSNUMERO: i32 = 156384712;
+
+pub const EACCES:           i32 = errno::EACCES;
+pub const EADDRINUSE:       i32 = errno::EADDRINUSE;
+pub const EAGAIN:           i32 = errno::EAGAIN;
+pub const EBUSY:            i32 = errno::EBUSY;
+pub const ECONNREFUSED:     i32 = errno::ECONNREFUSED;
+pub const EFAULT:           i32 = errno::EFAULT;
+pub const EINTR:            i32 = errno::EINTR;
+pub const EHOSTUNREACH:     i32 = errno::EHOSTUNREACH;
+pub const EINPROGRESS:      i32 = errno::EINPROGRESS;
+pub const EINVAL:           i32 = errno::EINVAL;
+pub const EMFILE:           i32 = errno::EMFILE;
+pub const EMSGSIZE:         i32 = errno::EMSGSIZE;
+pub const ENAMETOOLONG:     i32 = errno::ENAMETOOLONG;
+pub const ENODEV:           i32 = errno::ENODEV;
+pub const ENOENT:           i32 = errno::ENOENT;
+pub const ENOMEM:           i32 = errno::ENOMEM;
+pub const ENOTCONN:         i32 = errno::ENOTCONN;
+pub const ENOTSOCK:         i32 = errno::ENOTSOCK;
+pub const EPROTO:           i32 = errno::EPROTO;
+pub const EPROTONOSUPPORT:  i32 = errno::EPROTONOSUPPORT;
+
+#[cfg(not(target_os = "windows"))]
+pub const ENOTSUP:          i32 = (ZMQ_HAUSNUMERO + 1);
+#[cfg(target_os = "windows")]
+pub const ENOTSUP:          i32 = errno::ENOTSUP;
+
+pub const ENOBUFS:          i32 = errno::ENOBUFS;
+pub const ENETDOWN:         i32 = errno::ENETDOWN;
+pub const EADDRNOTAVAIL:    i32 = errno::EADDRNOTAVAIL;
+
+// native zmq error codes
+pub const EFSM:             i32 = (ZMQ_HAUSNUMERO + 51);
+pub const ENOCOMPATPROTO:   i32 = (ZMQ_HAUSNUMERO + 52);
+pub const ETERM:            i32 = (ZMQ_HAUSNUMERO + 53);
+pub const EMTHREAD:         i32 = (ZMQ_HAUSNUMERO + 54);

--- a/zmq-sys/src/lib.rs
+++ b/zmq-sys/src/lib.rs
@@ -1,7 +1,9 @@
 
 extern crate libc;
 
+#[cfg(target_os = "windows")]
 mod win_errno;
+
 pub mod errno;
 
 pub use ffi::{

--- a/zmq-sys/src/lib.rs
+++ b/zmq-sys/src/lib.rs
@@ -1,6 +1,9 @@
 
 extern crate libc;
 
+mod win_errno;
+pub mod errno;
+
 pub use ffi::{
     zmq_msg_t,
     zmq_free_fn,

--- a/zmq-sys/src/win_errno.rs
+++ b/zmq-sys/src/win_errno.rs
@@ -1,0 +1,28 @@
+use libc::c_int;
+
+// Use constants as defined in the windows header errno.h
+// libzmq should be compiled with VS2010 SDK headers or newer
+pub const EACCES: c_int = 13;
+pub const EADDRINUSE: c_int = 100;
+pub const EADDRNOTAVAIL: c_int = 101;
+pub const EAGAIN: c_int = 11;
+pub const EBUSY: c_int = 16;
+pub const ECONNREFUSED: c_int = 107;
+pub const EFAULT: c_int = 14;
+pub const EINTR: c_int = 4;
+pub const EHOSTUNREACH: c_int = 110;
+pub const EINPROGRESS: c_int = 112;
+pub const EINVAL: c_int = 22;
+pub const EMFILE: c_int = 24;
+pub const EMSGSIZE: c_int = 115;
+pub const ENAMETOOLONG: c_int = 38;
+pub const ENETDOWN: c_int = 116;
+pub const ENOBUFS: c_int = 119;
+pub const ENODEV: c_int = 19;
+pub const ENOENT: c_int = 2;
+pub const ENOMEM: c_int = 12;
+pub const ENOTCONN: c_int = 126;
+pub const ENOTSOCK: c_int = 128;
+pub const ENOTSUP: c_int = 129;
+pub const EPROTO: c_int = 134;
+pub const EPROTONOSUPPORT: c_int = 135;


### PR DESCRIPTION
There is also a fix for an off-by-one memory error. All tests passing on rustc 1.12.0 i686-pc-windows-msvc and rustc 1.12.0 x86_64-unknown-linux-gnu.
