### PR TITLE
Don't require a mutable borrow to create sockets

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ Usage
 extern crate zmq;
 
 fn main() {
-    let mut ctx = zmq::Context::new();
+    let ctx = zmq::Context::new();
 
     let mut socket = ctx.socket(zmq::REQ).unwrap();
     socket.connect("tcp://127.0.0.1:1234").unwrap();

--- a/examples/zguide/helloworld_client/main.rs
+++ b/examples/zguide/helloworld_client/main.rs
@@ -7,7 +7,7 @@ extern crate zmq;
 fn main() {
     println!("Connecting to hello world server...\n");
 
-    let mut context = zmq::Context::new();
+    let context = zmq::Context::new();
     let mut requester = context.socket(zmq::REQ).unwrap();
 
     assert!(requester.connect("tcp://localhost:5555").is_ok());

--- a/examples/zguide/helloworld_server/main.rs
+++ b/examples/zguide/helloworld_server/main.rs
@@ -10,7 +10,7 @@ use std::thread;
 use std::time::Duration;
 
 fn main() {
-    let mut context = zmq::Context::new();
+    let context = zmq::Context::new();
     let mut responder = context.socket(zmq::REP).unwrap();
 
     assert!(responder.bind("tcp://*:5555").is_ok());

--- a/examples/zguide/msreader/main.rs
+++ b/examples/zguide/msreader/main.rs
@@ -9,7 +9,7 @@ use std::time::Duration;
 use std::thread;
 
 fn main() {
-    let mut context = zmq::Context::new();
+    let context = zmq::Context::new();
 
     // Connect to task ventilator
     let mut receiver = context.socket(zmq::PULL).unwrap();

--- a/examples/zguide/tasksink/main.rs
+++ b/examples/zguide/tasksink/main.rs
@@ -9,7 +9,7 @@ use std::time::Instant;
 
 fn main() {
     //  Prepare our context and socket
-    let mut context = zmq::Context::new();
+    let context = zmq::Context::new();
     let mut receiver = context.socket(zmq::PULL).unwrap();
     assert!(receiver.bind("tcp://*:5558").is_ok());
     

--- a/examples/zguide/taskvent/main.rs
+++ b/examples/zguide/taskvent/main.rs
@@ -11,7 +11,7 @@ use std::io::{self,BufRead};
 use rand::Rng;
 
 fn main() {
-    let mut context = zmq::Context::new();
+    let context = zmq::Context::new();
 
     // Socket to send messages on
     let mut sender = context.socket(zmq::PUSH).unwrap();

--- a/examples/zguide/taskwork/main.rs
+++ b/examples/zguide/taskwork/main.rs
@@ -13,7 +13,7 @@ use std::thread;
 use std::time::Duration;
 
 fn main() {
-    let mut context = zmq::Context::new();
+    let context = zmq::Context::new();
 
     // socket to receive messages on
     let mut receiver = context.socket(zmq::PULL).unwrap();

--- a/examples/zguide/weather_client/main.rs
+++ b/examples/zguide/weather_client/main.rs
@@ -17,7 +17,7 @@ fn atoi(s: &str) -> i64 {
 fn main() {
     println!("Collecting updates from weather server...");
 
-    let mut context = zmq::Context::new();
+    let context = zmq::Context::new();
     let mut subscriber = context.socket(zmq::SUB).unwrap();
     assert!(subscriber.connect("tcp://localhost:5556").is_ok());
 

--- a/examples/zguide/weather_server/main.rs
+++ b/examples/zguide/weather_server/main.rs
@@ -10,7 +10,7 @@ extern crate zmq;
 use rand::Rng;
 
 fn main() {
-    let mut context = zmq::Context::new();
+    let context = zmq::Context::new();
     let mut publisher = context.socket(zmq::PUB).unwrap();
 
     assert!(publisher.bind("tcp://*:5556").is_ok());

--- a/tests/compile-fail/no-leaking-poll-items.rs
+++ b/tests/compile-fail/no-leaking-poll-items.rs
@@ -1,7 +1,7 @@
 extern crate zmq;
 
 fn main() {
-    let mut context = zmq::Context::new();
+    let context = zmq::Context::new();
     let _poll_item = {
         let socket = context.socket(zmq::PAIR).unwrap();
         socket.as_poll_item(0)

--- a/tests/shared-context.rs
+++ b/tests/shared-context.rs
@@ -1,0 +1,41 @@
+extern crate zmq;
+
+use std::thread;
+use std::str;
+
+#[test]
+fn test_shared_context() {
+    let ctx = zmq::Context::new();
+
+    let address = "inproc://pub";
+    let mut push_socket = ctx.socket(zmq::PUSH).unwrap();
+    push_socket.bind(address).unwrap();
+    let worker1 = fork(&ctx);
+
+    push_socket.send("Message1".as_bytes(), 0).unwrap();
+
+    worker1.join().unwrap();
+}
+
+fn fork(ctx: &zmq::Context) -> thread::JoinHandle<()> {
+    let w_ctx = ctx.clone();
+    thread::spawn(move || { worker(&w_ctx); })
+}
+
+fn worker(ctx: &zmq::Context) {
+    let mut pull_socket = connect_socket(ctx, zmq::PULL, "inproc://pub").unwrap();
+
+    let mut msg = zmq::Message::new().unwrap();
+    pull_socket.recv(&mut msg, 0).unwrap();
+    assert_eq!(&msg[..], "Message1".as_bytes());
+}
+
+fn connect_socket<'a>(ctx: &'a zmq::Context,
+                      typ: zmq::SocketType,
+                      address: &str) -> Result<zmq::Socket, zmq::Error> {
+    ctx.socket(typ)
+        .and_then(|mut socket| match socket.connect(address) {
+            Ok(()) => Ok(socket),
+            Err(e) => Err(e)
+        })
+}

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -1,6 +1,14 @@
 extern crate zmq;
 use zmq::*;
 
+#[test]
+fn test_raw_roundtrip() {
+    let ctx = Context::new();
+
+    let raw = ctx.socket(SocketType::REQ).unwrap().into_raw();;
+    let _ = unsafe { Socket::from_raw(raw) };
+}
+
 #[cfg(ZMQ_HAS_CURVE = "1")]
 #[test]
 fn test_curve_keypair() {
@@ -11,7 +19,7 @@ fn test_curve_keypair() {
 
 #[test]
 fn test_get_socket_type() {
-    let mut ctx = Context::new();
+    let ctx = Context::new();
 
     let mut socket_types = vec![
         SocketType::PAIR,
@@ -34,7 +42,7 @@ fn test_get_socket_type() {
 
 #[test]
 fn test_getset_maxmsgsize() {
-    let mut ctx = Context::new();
+    let ctx = Context::new();
     let sock = ctx.socket(REQ).unwrap();
     sock.set_maxmsgsize(512000).unwrap();
     assert_eq!(sock.get_maxmsgsize().unwrap(), 512000);
@@ -42,7 +50,7 @@ fn test_getset_maxmsgsize() {
 
 #[test]
 fn test_getset_sndhwm() {
-    let mut ctx = Context::new();
+    let ctx = Context::new();
     let sock = ctx.socket(REQ).unwrap();
     sock.set_sndhwm(500).unwrap();
     assert_eq!(sock.get_sndhwm().unwrap(), 500);
@@ -50,7 +58,7 @@ fn test_getset_sndhwm() {
 
 #[test]
 fn test_getset_rcvhwm() {
-    let mut ctx = Context::new();
+    let ctx = Context::new();
     let sock = ctx.socket(REQ).unwrap();
     sock.set_rcvhwm(500).unwrap();
     assert_eq!(sock.get_rcvhwm().unwrap(), 500);
@@ -58,7 +66,7 @@ fn test_getset_rcvhwm() {
 
 #[test]
 fn test_getset_affinity() {
-    let mut ctx = Context::new();
+    let ctx = Context::new();
     let sock = ctx.socket(REQ).unwrap();
     sock.set_affinity(1024).unwrap();
     assert_eq!(sock.get_affinity().unwrap(), 1024);
@@ -66,7 +74,7 @@ fn test_getset_affinity() {
 
 #[test]
 fn test_getset_identity() {
-    let mut ctx = Context::new();
+    let ctx = Context::new();
     let sock = ctx.socket(REQ).unwrap();
     sock.set_identity("moo".as_bytes()).unwrap();
     assert_eq!(sock.get_identity().unwrap().unwrap(), "moo");
@@ -74,7 +82,7 @@ fn test_getset_identity() {
 
 #[test]
 fn test_subscription() {
-    let mut ctx = Context::new();
+    let ctx = Context::new();
     let sock = ctx.socket(SUB).unwrap();
     assert!(sock.set_subscribe("/channel".as_bytes()).is_ok());
     assert!(sock.set_unsubscribe("/channel".as_bytes()).is_ok());
@@ -82,7 +90,7 @@ fn test_subscription() {
 
 #[test]
 fn test_getset_rate() {
-    let mut ctx = Context::new();
+    let ctx = Context::new();
     let sock = ctx.socket(REQ).unwrap();
     sock.set_rate(200).unwrap();
     assert_eq!(sock.get_rate().unwrap(), 200);
@@ -90,7 +98,7 @@ fn test_getset_rate() {
 
 #[test]
 fn test_getset_recovery_ivl() {
-    let mut ctx = Context::new();
+    let ctx = Context::new();
     let sock = ctx.socket(REQ).unwrap();
     sock.set_recovery_ivl(100).unwrap();
     assert_eq!(sock.get_recovery_ivl().unwrap(), 100);
@@ -98,7 +106,7 @@ fn test_getset_recovery_ivl() {
 
 #[test]
 fn test_getset_sndbuf() {
-    let mut ctx = Context::new();
+    let ctx = Context::new();
     let sock = ctx.socket(REQ).unwrap();
     sock.set_sndbuf(100).unwrap();
     assert_eq!(sock.get_sndbuf().unwrap(), 100);
@@ -106,7 +114,7 @@ fn test_getset_sndbuf() {
 
 #[test]
 fn test_getset_rcvbuf() {
-    let mut ctx = Context::new();
+    let ctx = Context::new();
     let sock = ctx.socket(REQ).unwrap();
     sock.set_rcvbuf(100).unwrap();
     assert_eq!(sock.get_rcvbuf().unwrap(), 100);
@@ -114,7 +122,7 @@ fn test_getset_rcvbuf() {
 
 #[test]
 fn test_getset_tos() {
-    let mut ctx = Context::new();
+    let ctx = Context::new();
     let sock = ctx.socket(REQ).unwrap();
     sock.set_tos(100).unwrap();
     assert_eq!(sock.get_tos().unwrap(), 100);
@@ -122,7 +130,7 @@ fn test_getset_tos() {
 
 #[test]
 fn test_getset_linger() {
-    let mut ctx = Context::new();
+    let ctx = Context::new();
     let sock = ctx.socket(REQ).unwrap();
     sock.set_linger(100).unwrap();
     assert_eq!(sock.get_linger().unwrap(), 100);
@@ -130,7 +138,7 @@ fn test_getset_linger() {
 
 #[test]
 fn test_getset_reconnect_ivl() {
-    let mut ctx = Context::new();
+    let ctx = Context::new();
     let sock = ctx.socket(REQ).unwrap();
     sock.set_reconnect_ivl(100).unwrap();
     assert_eq!(sock.get_reconnect_ivl().unwrap(), 100);
@@ -138,7 +146,7 @@ fn test_getset_reconnect_ivl() {
 
 #[test]
 fn test_getset_reconnect_ivl_max() {
-    let mut ctx = Context::new();
+    let ctx = Context::new();
     let sock = ctx.socket(REQ).unwrap();
     sock.set_reconnect_ivl_max(100).unwrap();
     assert_eq!(sock.get_reconnect_ivl_max().unwrap(), 100);
@@ -146,7 +154,7 @@ fn test_getset_reconnect_ivl_max() {
 
 #[test]
 fn test_getset_backlog() {
-    let mut ctx = Context::new();
+    let ctx = Context::new();
     let sock = ctx.socket(REQ).unwrap();
     sock.set_backlog(50).unwrap();
     assert_eq!(sock.get_backlog().unwrap(), 50);
@@ -154,7 +162,7 @@ fn test_getset_backlog() {
 
 #[test]
 fn test_getset_multicast_hops() {
-    let mut ctx = Context::new();
+    let ctx = Context::new();
     let sock = ctx.socket(REQ).unwrap();
     sock.set_multicast_hops(20).unwrap();
     assert_eq!(sock.get_multicast_hops().unwrap(), 20);
@@ -162,7 +170,7 @@ fn test_getset_multicast_hops() {
 
 #[test]
 fn test_getset_rcvtimeo() {
-    let mut ctx = Context::new();
+    let ctx = Context::new();
     let sock = ctx.socket(REQ).unwrap();
     sock.set_rcvtimeo(5000).unwrap();
     assert_eq!(sock.get_rcvtimeo().unwrap(), 5000);
@@ -170,7 +178,7 @@ fn test_getset_rcvtimeo() {
 
 #[test]
 fn test_getset_sndtimeo() {
-    let mut ctx = Context::new();
+    let ctx = Context::new();
     let sock = ctx.socket(REQ).unwrap();
     sock.set_sndtimeo(5000).unwrap();
     assert_eq!(sock.get_sndtimeo().unwrap(), 5000);
@@ -178,7 +186,7 @@ fn test_getset_sndtimeo() {
 
 #[test]
 fn test_getset_ipv6() {
-    let mut ctx = Context::new();
+    let ctx = Context::new();
     let sock = ctx.socket(REQ).unwrap();
 
     sock.set_ipv6(true).unwrap();
@@ -190,7 +198,7 @@ fn test_getset_ipv6() {
 
 #[test]
 fn test_getset_socks_proxy() {
-    let mut ctx = Context::new();
+    let ctx = Context::new();
     let sock = ctx.socket(REQ).unwrap();
 
     sock.set_socks_proxy(Some("my_socks_server.com:10080")).unwrap();
@@ -202,7 +210,7 @@ fn test_getset_socks_proxy() {
 
 #[test]
 fn test_getset_keepalive() {
-    let mut ctx = Context::new();
+    let ctx = Context::new();
     let sock = ctx.socket(REQ).unwrap();
 
     sock.set_tcp_keepalive(-1).unwrap();
@@ -217,7 +225,7 @@ fn test_getset_keepalive() {
 
 #[test]
 fn test_getset_keepalive_cnt() {
-    let mut ctx = Context::new();
+    let ctx = Context::new();
     let sock = ctx.socket(REQ).unwrap();
 
     sock.set_tcp_keepalive_cnt(-1).unwrap();
@@ -229,7 +237,7 @@ fn test_getset_keepalive_cnt() {
 
 #[test]
 fn test_getset_keepalive_idle() {
-    let mut ctx = Context::new();
+    let ctx = Context::new();
     let sock = ctx.socket(REQ).unwrap();
 
     sock.set_tcp_keepalive_idle(-1).unwrap();
@@ -241,7 +249,7 @@ fn test_getset_keepalive_idle() {
 
 #[test]
 fn test_getset_tcp_keepalive_intvl() {
-    let mut ctx = Context::new();
+    let ctx = Context::new();
     let sock = ctx.socket(REQ).unwrap();
 
     sock.set_tcp_keepalive_intvl(-1).unwrap();
@@ -253,7 +261,7 @@ fn test_getset_tcp_keepalive_intvl() {
 
 #[test]
 fn test_getset_immediate() {
-    let mut ctx = Context::new();
+    let ctx = Context::new();
     let sock = ctx.socket(REQ).unwrap();
 
     sock.set_immediate(true).unwrap();
@@ -265,7 +273,7 @@ fn test_getset_immediate() {
 
 #[test]
 fn test_getset_plain_server() {
-    let mut ctx = Context::new();
+    let ctx = Context::new();
     let sock = ctx.socket(REQ).unwrap();
 
     sock.set_plain_server(true).unwrap();
@@ -277,7 +285,7 @@ fn test_getset_plain_server() {
 
 #[test]
 fn test_getset_plain_username() {
-    let mut ctx = Context::new();
+    let ctx = Context::new();
     let sock = ctx.socket(REQ).unwrap();
 
     sock.set_plain_username(Some("billybob")).unwrap();
@@ -290,7 +298,7 @@ fn test_getset_plain_username() {
 
 #[test]
 fn test_getset_plain_password() {
-    let mut ctx = Context::new();
+    let ctx = Context::new();
     let sock = ctx.socket(REQ).unwrap();
 
     sock.set_plain_password(Some("m00c0w")).unwrap();
@@ -303,16 +311,29 @@ fn test_getset_plain_password() {
 
 #[test]
 fn test_getset_zap_domain() {
-    let mut ctx = Context::new();
+    let ctx = Context::new();
     let sock = ctx.socket(REQ).unwrap();
     sock.set_zap_domain("test_domain").unwrap();
     assert_eq!(sock.get_zap_domain().unwrap().unwrap(), "test_domain");
 }
 
+#[test]
+fn test_ctx_nohang() {
+    // Test that holding on to a socket keeps the context it was
+    // created from from being destroyed. Destroying the context while
+    // a socket is still open would block, thus hanging this test in
+    // the failing case.
+    let sock = {
+        let ctx = Context::new();
+        ctx.socket(REQ).unwrap()
+    };
+    assert_eq!(sock.get_socket_type(), Ok(REQ));
+}
+
 #[cfg(ZMQ_HAS_CURVE = "1")]
 #[test]
 fn test_getset_curve_server() {
-    let mut ctx = Context::new();
+    let ctx = Context::new();
     let sock = ctx.socket(REQ).unwrap();
     sock.set_curve_server(true).unwrap();
     assert_eq!(sock.is_curve_server().unwrap(), true);
@@ -321,7 +342,7 @@ fn test_getset_curve_server() {
 #[cfg(ZMQ_HAS_CURVE = "1")]
 #[test]
 fn test_getset_curve_publickey() {
-    let mut ctx = Context::new();
+    let ctx = Context::new();
     let sock = ctx.socket(REQ).unwrap();
     sock.set_curve_publickey("FX5b8g5ZnOk7$Q}^)Y&?.v3&MIe+]OU7DTKynkUL").unwrap();
     assert_eq!(sock.get_curve_publickey().unwrap().unwrap(), "FX5b8g5ZnOk7$Q}^)Y&?.v3&MIe+]OU7DTKynkUL");
@@ -330,7 +351,7 @@ fn test_getset_curve_publickey() {
 #[cfg(ZMQ_HAS_CURVE = "1")]
 #[test]
 fn test_getset_curve_secretkey() {
-    let mut ctx = Context::new();
+    let ctx = Context::new();
     let sock = ctx.socket(REQ).unwrap();
     sock.set_curve_secretkey("s9N%S3*NKSU$6pUnpBI&K5HBd[]G$Y3yrK?mhdbS").unwrap();
     assert_eq!(sock.get_curve_secretkey().unwrap().unwrap(), "s9N%S3*NKSU$6pUnpBI&K5HBd[]G$Y3yrK?mhdbS");
@@ -339,7 +360,7 @@ fn test_getset_curve_secretkey() {
 #[cfg(ZMQ_HAS_CURVE = "1")]
 #[test]
 fn test_getset_curve_serverkey() {
-    let mut ctx = Context::new();
+    let ctx = Context::new();
     let sock = ctx.socket(REQ).unwrap();
     sock.set_curve_serverkey("FX5b8g5ZnOk7$Q}^)Y&?.v3&MIe+]OU7DTKynkUL").unwrap();
     assert_eq!(sock.get_curve_serverkey().unwrap().unwrap(), "FX5b8g5ZnOk7$Q}^)Y&?.v3&MIe+]OU7DTKynkUL");
@@ -347,7 +368,7 @@ fn test_getset_curve_serverkey() {
 
 #[test]
 fn test_getset_conflate() {
-    let mut ctx = Context::new();
+    let ctx = Context::new();
     let sock = ctx.socket(REQ).unwrap();
     sock.set_conflate(true).unwrap();
     assert_eq!(sock.is_conflate().unwrap(), true);
@@ -356,7 +377,7 @@ fn test_getset_conflate() {
 #[cfg(ZMQ_HAS_GSSAPI = "1")]
 #[test]
 fn test_getset_gssapi_server() {
-    let mut ctx = Context::new();
+    let ctx = Context::new();
     let sock = ctx.socket(REQ).unwrap();
     sock.set_gssapi_server(true).unwrap();
     assert_eq!(sock.is_gssapi_server().unwrap(), true);
@@ -365,7 +386,7 @@ fn test_getset_gssapi_server() {
 #[cfg(ZMQ_HAS_GSSAPI = "1")]
 #[test]
 fn test_getset_gssapi_principal() {
-    let mut ctx = Context::new();
+    let ctx = Context::new();
     let sock = ctx.socket(REQ).unwrap();
     sock.set_gssapi_principal("principal").unwrap();
     assert_eq!(sock.get_gssapi_principal().unwrap().unwrap(), "principal");
@@ -374,7 +395,7 @@ fn test_getset_gssapi_principal() {
 #[cfg(ZMQ_HAS_GSSAPI = "1")]
 #[test]
 fn test_getset_gssapi_service_principal() {
-    let mut ctx = Context::new();
+    let ctx = Context::new();
     let sock = ctx.socket(REQ).unwrap();
     sock.set_gssapi_service_principal("principal").unwrap();
     assert_eq!(sock.get_gssapi_service_principal().unwrap().unwrap(), "principal");
@@ -383,7 +404,7 @@ fn test_getset_gssapi_service_principal() {
 #[cfg(ZMQ_HAS_GSSAPI = "1")]
 #[test]
 fn test_getset_gssapi_plaintext() {
-    let mut ctx = Context::new();
+    let ctx = Context::new();
     let sock = ctx.socket(REQ).unwrap();
     sock.set_gssapi_plaintext(true).unwrap();
     assert_eq!(sock.is_gssapi_plaintext().unwrap(), true);
@@ -392,7 +413,7 @@ fn test_getset_gssapi_plaintext() {
 #[cfg(ZMQ_HAS_GSSAPI = "1")]
 #[test]
 fn test_getset_handshake_ivl() {
-    let mut ctx = Context::new();
+    let ctx = Context::new();
     let sock = ctx.socket(REQ).unwrap();
     sock.set_handshake_ivl(50000).unwrap();
     assert_eq!(sock.get_handshake_ivl().unwrap(), 50000);


### PR DESCRIPTION
Based on alexcamp's work, specifically commits 25fb5820..dbadcb81, this
API change allows sharing a `Context` between threads, while still being
able to create sockets from them.

This is a thing possible in C (obviously), but was forbidden by the Rust
API, due to `Context::socket` taking a mutable self reference. The zmq
context is thread-safe, as noted in zmq(7):

  A ØMQ context is thread safe and may be shared among as many
  application threads as necessary, without any additional locking
  required on the part of the caller.

As dropping a context with live sockets is a defined action, as well,
according to zmq_ctx_destroy(3), it should be safe to enable the
creation of sockets via aliases to the context in different threads.

This commit should fix issue #64.
