### PR TITLE
Activate compiletest_rs feature

### DIFF
--- a/tests/test.rs
+++ b/tests/test.rs
@@ -405,3 +405,26 @@ fn test_getset_handshake_ivl() {
     sock.set_handshake_ivl(50000).unwrap();
     assert_eq!(sock.get_handshake_ivl().unwrap(), 50000);
 }
+
+#[cfg(feature = "compiletest_rs")]
+mod compile {
+    extern crate compiletest_rs as compiletest;
+
+    use std::path::PathBuf;
+
+    fn run_mode(mode: &'static str) {
+        let mut config = compiletest::default_config();
+        let cfg_mode = mode.parse().ok().expect("Invalid mode");
+
+        config.mode = cfg_mode;
+        config.src_base = PathBuf::from(format!("tests/{}", mode));
+        config.target_rustcflags = Some("-L target/debug -L target/debug/deps".to_string());
+
+        compiletest::run_tests(&config);
+    }
+
+    #[test]
+    fn expected_failures() {
+        run_mode("compile-fail");
+    }
+}


### PR DESCRIPTION
This change adds missing integration of compiletest-rs into the test
suite, so compiletests are run by "cargo test" if the compiletest_rs
feature is selected. Also, pull compiletest-rs directly from github, as
the last-published version didn't compile with the rustc from current
master.
