### PR TITLE
	Make most socket methods operate on immutable self

### DIFF
--- a/examples/zguide/fileio3/main.rs
+++ b/examples/zguide/fileio3/main.rs
@@ -27,7 +27,7 @@ fn random_string(length: usize) -> String {
 
 fn client_thread(expected_total: usize) {
     let context = zmq::Context::new();
-    let mut dealer = context.socket(zmq::DEALER).unwrap();
+    let dealer = context.socket(zmq::DEALER).unwrap();
     let identity: Vec<u8> = (0..10).map(|_| rand::random::<u8>()).collect();
     dealer.set_identity(&identity).unwrap();
 
@@ -78,7 +78,7 @@ fn client_thread(expected_total: usize) {
 
 fn server_thread(file: &mut File) -> Result<(), Error> {
     let context = zmq::Context::new();
-    let mut router = context.socket(zmq::ROUTER).unwrap();
+    let router = context.socket(zmq::ROUTER).unwrap();
     // We have two parts per message so HWM is PIPELINE * 2
     router.set_sndhwm(PIPELINE_HWM as i32).unwrap();
     assert!(router.bind("tcp://*:6000").is_ok());

--- a/examples/zguide/helloworld_client/main.rs
+++ b/examples/zguide/helloworld_client/main.rs
@@ -8,7 +8,7 @@ fn main() {
     println!("Connecting to hello world server...\n");
 
     let context = zmq::Context::new();
-    let mut requester = context.socket(zmq::REQ).unwrap();
+    let requester = context.socket(zmq::REQ).unwrap();
 
     assert!(requester.connect("tcp://localhost:5555").is_ok());
 

--- a/examples/zguide/helloworld_server/main.rs
+++ b/examples/zguide/helloworld_server/main.rs
@@ -11,7 +11,7 @@ use std::time::Duration;
 
 fn main() {
     let context = zmq::Context::new();
-    let mut responder = context.socket(zmq::REP).unwrap();
+    let responder = context.socket(zmq::REP).unwrap();
 
     assert!(responder.bind("tcp://*:5555").is_ok());
 

--- a/examples/zguide/msreader/main.rs
+++ b/examples/zguide/msreader/main.rs
@@ -12,11 +12,11 @@ fn main() {
     let context = zmq::Context::new();
 
     // Connect to task ventilator
-    let mut receiver = context.socket(zmq::PULL).unwrap();
+    let receiver = context.socket(zmq::PULL).unwrap();
     assert!(receiver.connect("tcp://localhost:5557").is_ok());
 
     // Connect to weather server
-    let mut subscriber = context.socket(zmq::SUB).unwrap();
+    let subscriber = context.socket(zmq::SUB).unwrap();
     assert!(subscriber.connect("tcp://localhost:5556").is_ok());
     let filter = b"10001";
     assert!(subscriber.set_subscribe(filter).is_ok());

--- a/examples/zguide/rtdealer/main.rs
+++ b/examples/zguide/rtdealer/main.rs
@@ -17,7 +17,7 @@ fn hex(bytes: &[u8]) -> String {
 
 fn worker_task() {
     let context = zmq::Context::new();
-    let mut worker = context.socket(zmq::DEALER).unwrap();
+    let worker = context.socket(zmq::DEALER).unwrap();
     let mut rng = rand::thread_rng();
     let identity: Vec<_> = (0..10).map(|_| rand::random::<u8>()).collect();
     worker.set_identity(&identity).unwrap();
@@ -48,7 +48,7 @@ fn main() {
     let worker_pool_size = 10;
     let allowed_duration = Duration::new(5, 0);
     let context = zmq::Context::new();
-    let mut broker = context.socket(zmq::ROUTER).unwrap();
+    let broker = context.socket(zmq::ROUTER).unwrap();
     assert!(broker.bind("tcp://*:5671").is_ok());
 
     // While this example runs in a single process, that is just to make

--- a/examples/zguide/tasksink/main.rs
+++ b/examples/zguide/tasksink/main.rs
@@ -12,7 +12,7 @@ use std::time::Instant;
 fn main() {
     //  Prepare our context and socket
     let context = zmq::Context::new();
-    let mut receiver = context.socket(zmq::PULL).unwrap();
+    let receiver = context.socket(zmq::PULL).unwrap();
     assert!(receiver.bind("tcp://*:5558").is_ok());
 
     // Wait for start of batch

--- a/examples/zguide/taskvent/main.rs
+++ b/examples/zguide/taskvent/main.rs
@@ -14,11 +14,11 @@ fn main() {
     let context = zmq::Context::new();
 
     // Socket to send messages on
-    let mut sender = context.socket(zmq::PUSH).unwrap();
+    let sender = context.socket(zmq::PUSH).unwrap();
     assert!(sender.bind("tcp://*:5557").is_ok());
 
     //  Socket to send start of batch message on
-    let mut sink = context.socket(zmq::PUSH).unwrap();
+    let sink = context.socket(zmq::PUSH).unwrap();
     assert!(sink.connect("tcp://localhost:5558").is_ok());
 
     println!("Press Enter when the workers are ready: ");

--- a/examples/zguide/taskwork/main.rs
+++ b/examples/zguide/taskwork/main.rs
@@ -20,11 +20,11 @@ fn main() {
     let context = zmq::Context::new();
 
     // socket to receive messages on
-    let mut receiver = context.socket(zmq::PULL).unwrap();
+    let receiver = context.socket(zmq::PULL).unwrap();
     assert!(receiver.connect("tcp://localhost:5557").is_ok());
 
     //  Socket to send messages to
-    let mut sender = context.socket(zmq::PUSH).unwrap();
+    let sender = context.socket(zmq::PUSH).unwrap();
     assert!(sender.connect("tcp://localhost:5558").is_ok());
 
     loop {

--- a/examples/zguide/weather_client/main.rs
+++ b/examples/zguide/weather_client/main.rs
@@ -18,7 +18,7 @@ fn main() {
     println!("Collecting updates from weather server...");
 
     let context = zmq::Context::new();
-    let mut subscriber = context.socket(zmq::SUB).unwrap();
+    let subscriber = context.socket(zmq::SUB).unwrap();
     assert!(subscriber.connect("tcp://localhost:5556").is_ok());
 
     let args: Vec<String> = env::args().collect();

--- a/examples/zguide/weather_server/main.rs
+++ b/examples/zguide/weather_server/main.rs
@@ -11,7 +11,7 @@ use rand::Rng;
 
 fn main() {
     let context = zmq::Context::new();
-    let mut publisher = context.socket(zmq::PUB).unwrap();
+    let publisher = context.socket(zmq::PUB).unwrap();
 
     assert!(publisher.bind("tcp://*:5556").is_ok());
     assert!(publisher.bind("ipc://weather.ipc").is_ok());

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -577,38 +577,36 @@ impl Socket {
     }
 
     /// Accept connections on a socket.
-    pub fn bind(&mut self, endpoint: &str) -> Result<()> {
+    pub fn bind(&self, endpoint: &str) -> Result<()> {
         let c_str = ffi::CString::new(endpoint.as_bytes()).unwrap();
         zmq_try!(unsafe { zmq_sys::zmq_bind(self.sock, c_str.as_ptr()) });
         Ok(())
     }
 
     /// Connect a socket.
-    pub fn connect(&mut self, endpoint: &str) -> Result<()> {
+    pub fn connect(&self, endpoint: &str) -> Result<()> {
         let c_str = ffi::CString::new(endpoint.as_bytes()).unwrap();
         zmq_try!(unsafe { zmq_sys::zmq_connect(self.sock, c_str.as_ptr()) });
         Ok(())
     }
 
     /// Send a `&[u8]` message.
-    pub fn send(&mut self, data: &[u8], flags: i32) -> Result<()> {
+    pub fn send(&self, data: &[u8], flags: i32) -> Result<()> {
         let msg = try!(Message::from_slice(data));
         self.send_msg(msg, flags)
     }
 
     /// Send a `Message` message.
-    pub fn send_msg(&mut self, mut msg: Message, flags: i32) -> Result<()> {
+    pub fn send_msg(&self, mut msg: Message, flags: i32) -> Result<()> {
         zmq_try!(unsafe { zmq_sys::zmq_msg_send(&mut msg.msg, self.sock, flags as c_int) });
         Ok(())
     }
 
-    /// Send a UTF-8 encoded string message.
-    pub fn send_str(&mut self, data: &str, flags: i32) -> Result<()> {
+    pub fn send_str(&self, data: &str, flags: i32) -> Result<()> {
         self.send(data.as_bytes(), flags)
     }
 
-    /// Send a multipart message.
-    pub fn send_multipart(&mut self, parts: &[&[u8]], flags: i32) -> Result<()> {
+    pub fn send_multipart(&self, parts: &[&[u8]], flags: i32) -> Result<()> {
         if parts.is_empty() {
             return Ok(());
         }
@@ -624,26 +622,26 @@ impl Socket {
 
     /// Receive a message into a `Message`. The length passed to zmq_msg_recv
     /// is the length of the buffer.
-    pub fn recv(&mut self, msg: &mut Message, flags: i32) -> Result<()> {
+    pub fn recv(&self, msg: &mut Message, flags: i32) -> Result<()> {
         zmq_try!(unsafe { zmq_sys::zmq_msg_recv(&mut msg.msg, self.sock, flags as c_int) });
         Ok(())
     }
 
     /// Receive bytes into a slice. The length passed to zmq_recv is the length of the slice.
-    pub fn recv_into(&mut self, bytes: &mut [u8], flags: i32) -> Result<()> {
+    pub fn recv_into(&self, bytes: &mut [u8], flags: i32) -> Result<()> {
         let bytes_ptr = bytes.as_mut_ptr() as *mut c_void;
         zmq_try!(unsafe { zmq_sys::zmq_recv(self.sock, bytes_ptr, bytes.len(), flags as c_int) });
         Ok(())
     }
 
     /// Receive a message into a fresh `Message`.
-    pub fn recv_msg(&mut self, flags: i32) -> Result<Message> {
+    pub fn recv_msg(&self, flags: i32) -> Result<Message> {
         let mut msg = try!(Message::new());
         self.recv(&mut msg, flags).map(|_| msg)
     }
 
     /// Receive a message as a byte vector.
-    pub fn recv_bytes(&mut self, flags: i32) -> Result<Vec<u8>> {
+    pub fn recv_bytes(&self, flags: i32) -> Result<Vec<u8>> {
         self.recv_msg(flags).map(|msg| msg.to_vec())
     }
 
@@ -651,7 +649,7 @@ impl Socket {
     ///
     /// If the received message is not valid UTF-8, it is returned as the original
     /// Vec in the `Err` part of the inner result.
-    pub fn recv_string(&mut self, flags: i32) -> Result<result::Result<String, Vec<u8>>> {
+    pub fn recv_string(&self, flags: i32) -> Result<result::Result<String, Vec<u8>>> {
         self.recv_bytes(flags).map(|bytes| String::from_utf8(bytes).map_err(|e| e.into_bytes()))
     }
 
@@ -660,7 +658,7 @@ impl Socket {
     /// Note that this will allocate a new vector for each message part; for
     /// many applications it will be possible to process the different parts
     /// sequentially and reuse allocations that way.
-    pub fn recv_multipart(&mut self, flags: i32) -> Result<Vec<Vec<u8>>> {
+    pub fn recv_multipart(&self, flags: i32) -> Result<Vec<Vec<u8>>> {
         let mut parts: Vec<Vec<u8>> = vec![];
         loop {
             let part = try!(self.recv_bytes(flags));

--- a/tests/compile-fail/socket-thread-unsafe.rs
+++ b/tests/compile-fail/socket-thread-unsafe.rs
@@ -1,0 +1,20 @@
+extern crate zmq;
+
+use std::thread;
+
+macro_rules! t {
+    ($e:expr) => (
+        $e.unwrap_or_else(|e| { panic!("{} failed with {:?}", stringify!($e), e) })
+    )
+}
+
+fn main() {
+    let mut context = zmq::Context::new();
+    let socket = t!(context.socket(zmq::REP));
+    let s = &socket;
+    let t = thread::spawn(move || {  //~ ERROR he trait bound `*mut std::os::raw::c_void: std::marker::Sync` is not satisfied [E0277]
+        t!(s.bind("tcp://127.0.0.1:12345"))
+    });
+    socket.send(b"ABC", 0);
+    t.join().unwrap();
+}

--- a/tests/shared-context.rs
+++ b/tests/shared-context.rs
@@ -16,7 +16,7 @@ fn test_tcp() {
 fn shared_context(address: &str) {
     let ctx = zmq::Context::new();
 
-    let mut push_socket = ctx.socket(zmq::PUSH).unwrap();
+    let push_socket = ctx.socket(zmq::PUSH).unwrap();
     push_socket.bind(address).unwrap();
     let endpoint = push_socket.get_last_endpoint().unwrap().unwrap();
     let worker1 = fork(&ctx, endpoint);
@@ -32,7 +32,7 @@ fn fork(ctx: &zmq::Context, endpoint: String) -> thread::JoinHandle<()> {
 }
 
 fn worker(ctx: &zmq::Context, endpoint: &str) {
-    let mut pull_socket = connect_socket(ctx, zmq::PULL, endpoint).unwrap();
+    let pull_socket = connect_socket(ctx, zmq::PULL, endpoint).unwrap();
 
     let mut msg = zmq::Message::new().unwrap();
     pull_socket.recv(&mut msg, 0).unwrap();
@@ -42,6 +42,5 @@ fn worker(ctx: &zmq::Context, endpoint: &str) {
 fn connect_socket(ctx: &zmq::Context,
                   typ: zmq::SocketType,
                   address: &str) -> Result<zmq::Socket, zmq::Error> {
-    ctx.socket(typ)
-        .and_then(|mut socket| socket.connect(address).map(|_| socket))
+    ctx.socket(typ).and_then(|socket| socket.connect(address).map(|_| socket))
 }

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -4,8 +4,8 @@ use zmq::*;
 fn create_socketpair() -> (Socket, Socket) {
     let ctx = Context::default();
 
-    let mut sender = ctx.socket(zmq::REQ).unwrap();
-    let mut receiver = ctx.socket(zmq::REP).unwrap();
+    let sender = ctx.socket(zmq::REQ).unwrap();
+    let receiver = ctx.socket(zmq::REP).unwrap();
 
     receiver.bind("tcp://*:*").unwrap();
     let ep = receiver.get_last_endpoint().unwrap().unwrap();
@@ -16,7 +16,7 @@ fn create_socketpair() -> (Socket, Socket) {
 
 #[test]
 fn test_exchanging_messages() {
-    let (mut sender, mut receiver) = create_socketpair();
+    let (sender, receiver) = create_socketpair();
     sender.send_msg(Message::from_slice(b"foo").unwrap(), 0).unwrap();
     let msg = receiver.recv_msg(0).unwrap();
     assert_eq!(&msg[..], b"foo");
@@ -31,7 +31,7 @@ fn test_exchanging_messages() {
 
 #[test]
 fn test_exchanging_bytes() {
-    let (mut sender, mut receiver) = create_socketpair();
+    let (sender, receiver) = create_socketpair();
     sender.send(b"bar", 0).unwrap();
     assert_eq!(receiver.recv_bytes(0).unwrap(), b"bar");
 
@@ -43,7 +43,7 @@ fn test_exchanging_bytes() {
 
 #[test]
 fn test_exchanging_strings() {
-    let (mut sender, mut receiver) = create_socketpair();
+    let (sender, receiver) = create_socketpair();
     sender.send_str("bäz", 0).unwrap();
     assert_eq!(receiver.recv_string(0).unwrap().unwrap(), "bäz");
 
@@ -55,7 +55,7 @@ fn test_exchanging_strings() {
 
 #[test]
 fn test_exchanging_multipart() {
-    let (mut sender, mut receiver) = create_socketpair();
+    let (sender, receiver) = create_socketpair();
 
     // convenience API
     sender.send_multipart(&[b"foo", b"bar"], 0).unwrap();
@@ -76,7 +76,7 @@ fn test_exchanging_multipart() {
 
 #[test]
 fn test_polling() {
-    let (mut sender, receiver) = create_socketpair();
+    let (sender, receiver) = create_socketpair();
 
     // no message yet
     assert_eq!(receiver.poll(POLLIN, 1).unwrap(), 0);
@@ -112,7 +112,7 @@ fn test_zmq_error() {
     use std::error::Error as StdError;
 
     let ctx = Context::new();
-    let mut sock = ctx.socket(SocketType::REP).unwrap();
+    let sock = ctx.socket(SocketType::REP).unwrap();
 
     // cannot send from REP unless we received a message first
     let err = sock.send(b"...", 0).unwrap_err();


### PR DESCRIPTION
Note that this is really a single commit being proposed, which depends on PR #96. Github does not handle outstanding PRs that depend on each other well, unfortunatly.
