### PR TITLE
Improve the mini-tutorial of installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,11 +10,23 @@ Rust ZeroMQ bindings.
 Installation
 ------------
 
-Currently, rust-zmq requires ZeroMQ 4.1. For example, on recent
+Currently, rust-zmq requires at least ZeroMQ 4.1 or newer. For example, on recent
 Debian-based distributions, you can use the following command to get
 the prerequiste headers and library installed:
 
+```
     apt install libzmq3-dev
+
+```
+
+For Ubuntu 14.04 you must install the newer release of libzmq in the git repository: https://github.com/zeromq/libzmq/releases
+
+And for Ubuntu 16.04 you can install by terminal
+
+```
+    apt install libzmq5
+
+```
 
 rust-zmq uses [cargo](https://crates.io) to install. Users should add this to
 their `Cargo.toml` file:

--- a/README.md
+++ b/README.md
@@ -16,7 +16,6 @@ the prerequiste headers and library installed:
 
 ```
     apt install libzmq3-dev
-
 ```
 
 For Ubuntu 14.04 you must install the newer release of libzmq in the git repository: https://github.com/zeromq/libzmq/releases
@@ -25,7 +24,6 @@ And for Ubuntu 16.04 you can install by terminal
 
 ```
     apt install libzmq5
-
 ```
 
 rust-zmq uses [cargo](https://crates.io) to install. Users should add this to


### PR DESCRIPTION
I want to resolve the issue #106 , the current installation message at README.md is deprecated. If you install the libzmq3 at Ubuntu 14.04 you don't have the problem solved.

So, I modify the message from **ZeroMQ 4.1** to **at least ZeroMQ 4.1 or newer**, because I'm using **ZMQ 4.1 at Ubuntu 14.04** and **ZMQ 4.2 at Ubuntu 16.04**. And added a instruction to install ZMQ in Ubuntu 14.04 and Ubuntu 16.04.