### PR TITLE
Some bug fixes and idiomatic changes

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -634,25 +634,16 @@ impl Socket {
 
     pub fn recv_msg(&mut self, flags: i32) -> Result<Message> {
         let mut msg = try!(Message::new());
-        match self.recv(&mut msg, flags) {
-            Ok(()) => Ok(msg),
-            Err(e) => Err(e),
-        }
+        self.recv(&mut msg, flags).map(|_| msg)
     }
 
     pub fn recv_bytes(&mut self, flags: i32) -> Result<Vec<u8>> {
-        match self.recv_msg(flags) {
-            Ok(msg) => Ok(msg.to_vec()),
-            Err(e) => Err(e),
-        }
+        self.recv_msg(flags).map(|msg| msg.to_vec())
     }
 
     /// Read a `String` from the socket.
     pub fn recv_string(&mut self, flags: i32) -> Result<result::Result<String, Vec<u8>>> {
-        match self.recv_bytes(flags) {
-            Ok(msg) => Ok(Ok(String::from_utf8(msg).unwrap_or("".to_string()))),
-            Err(e) => Err(e),
-        }
+        self.recv_bytes(flags).map(|bytes| Ok(String::from_utf8(bytes).unwrap_or("".to_string())))
     }
 
     pub fn recv_multipart(&mut self, flags: i32) -> Result<Vec<Vec<u8>>> {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -643,7 +643,7 @@ impl Socket {
 
     /// Read a `String` from the socket.
     pub fn recv_string(&mut self, flags: i32) -> Result<result::Result<String, Vec<u8>>> {
-        self.recv_bytes(flags).map(|bytes| Ok(String::from_utf8(bytes).unwrap_or("".to_string())))
+        self.recv_bytes(flags).map(|bytes| String::from_utf8(bytes).map_err(|e| e.into_bytes()))
     }
 
     pub fn recv_multipart(&mut self, flags: i32) -> Result<Vec<Vec<u8>>> {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1038,12 +1038,12 @@ impl CurveKeyPair {
                 ffi_public_key.as_mut_ptr() as *mut libc::c_char,
                 ffi_secret_key.as_mut_ptr() as *mut libc::c_char);
 
-            let public_key = String::from_utf8(ffi_public_key).expect("key not utf8");
-            let secret_key = String::from_utf8(ffi_secret_key).expect("key not utf8");
-
             if rc == -1i32 {
                 Err(errno_to_error())
             } else {
+                let public_key = String::from_utf8(ffi_public_key).expect("key not utf8");
+                let secret_key = String::from_utf8(ffi_secret_key).expect("key not utf8");
+
                 Ok(CurveKeyPair {
                     public_key: public_key,
                     secret_key: secret_key,


### PR DESCRIPTION
These are logically independent, but touch the same code, so I thought it's best to put them into one PR.
Commits should be reviewed independently.

As for the last change, I thought it was best not to put the `unsafe {}` into the macro, to avoid hiding unsafe code locations.