### PR TITLE
Fix appveyor and get most windows tests to pass

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -1,23 +1,14 @@
+os:
+  - Visual Studio 2015
+clone_depth: 1
+configuration:
+  - Debug
+    #  - Release
+platform:
+  #- Win32
+  - x64
 environment:
-    CARGO_TARGET: x86_64-pc-windows-gnu
-    matrix:
-        - TARGET: x86_64-pc-windows-msvc
-        - TARGET: i686-pc-windows-gnu
-install:
-    - ps: Start-FileDownload "https://static.rust-lang.org/dist/rustc-nightly-${env:TARGET}.tar.gz"
-    - ps: Start-FileDownload "https://static.rust-lang.org/cargo-dist/cargo-nightly-${env:CARGO_TARGET}.tar.gz"
-    - 7z x rustc-nightly-%TARGET%.tar.gz > nul
-    - 7z x rustc-nightly-%TARGET%.tar > nul
-    - 7z x cargo-nightly-%CARGO_TARGET%.tar.gz > nul
-    - 7z x cargo-nightly-%CARGO_TARGET%.tar > nul
-    - call "C:\Program Files (x86)\Microsoft Visual Studio 12.0\VC\vcvarsall.bat" amd64
-    - set PATH=%PATH%;%cd%/rustc-nightly-%TARGET%/rustc/bin
-    - set PATH=%PATH%;%cd%/cargo-nightly-%CARGO_TARGET%/cargo/bin
-    - SET PATH=%PATH%;C:\MinGW\bin
-    - rustc -V
-    - cargo -V
-
-build: false
-
-test_script:
-    - cargo test --verbose
+  matrix:
+    - TOOLCHAIN_VERSION: 14.0
+      RUST: nightly
+build_script: .appveyor/appveyor.bat

--- a/.appveyor/appveyor.bat
+++ b/.appveyor/appveyor.bat
@@ -50,7 +50,6 @@ if %ERRORLEVEL% NEQ 0 (
 set SODIUM_LIBRARY_DIR="%LIBSODIUM_DIR%\bin\%SODIUM_PLATFORM%\%Configuration%\%MSVCVERSION%\dynamic"
 set SODIUM_INCLUDE_DIR="%LIBSODIUM_DIR%\src\libsodium\include"
 move "%SODIUM_LIBRARY_DIR%\libsodium.lib" "%SODIUM_LIBRARY_DIR%\sodium.lib"
-dir /s %LIBSODIUM_LIBRARY_DIR%
 if %ERRORLEVEL% NEQ 0 exit 1
 
 set PATH=%SODIUM_LIBRARY_DIR%;%PATH%
@@ -82,11 +81,8 @@ if %ERRORLEVEL% NEQ 0 (
 
 set LIBZMQ_INCLUDE_DIR=%LIBZMQ_SOURCEDIR%\include
 set LIBZMQ_LIB_DIR=%LIBZMQ_BUILDDIR%\lib\%Configuration%
-dir /s %LIBZMQ_SOURCEDIR%
 move "%LIBZMQ_LIB_DIR%\libzmq-*lib" "%LIBZMQ_LIB_DIR%\zmq.lib"
 set PATH=%LIBZMQ_BUILDDIR%\bin\%Configuration%;%PATH%
-dir /s %LIBZMQ_INCLUDE_DIR%
-dir /s %LIBZMQ_LIB_DIR%
 if %ERRORLEVEL% NEQ 0 exit 1
 
 cd %ORIGINAL_PATH%

--- a/.appveyor/appveyor.bat
+++ b/.appveyor/appveyor.bat
@@ -1,0 +1,121 @@
+echo on
+SetLocal EnableDelayedExpansion
+
+REM This is the recommended way to choose the toolchain version, according to
+REM Appveyor's documentation.
+SET PATH=C:\Program Files (x86)\MSBuild\%TOOLCHAIN_VERSION%\Bin;%PATH%
+
+set VCVARSALL="C:\Program Files (x86)\Microsoft Visual Studio %TOOLCHAIN_VERSION%\VC\vcvarsall.bat"
+set MSVCYEAR=vs2015
+set MSVCVERSION=v140
+
+if [%Platform%] NEQ [x64] goto win32
+set TARGET_ARCH=x86_64
+set TARGET_PROGRAM_FILES=%ProgramFiles%
+set SODIUM_PLATFORM=X64
+set CMAKE_GENERATOR="Visual Studio 14 2015 Win64"
+call %VCVARSALL% amd64
+if %ERRORLEVEL% NEQ 0 exit 1
+goto download
+
+:win32
+echo on
+if [%Platform%] NEQ [Win32] exit 1
+set TARGET_ARCH=i686
+set TARGET_PROGRAM_FILES=%ProgramFiles(x86)%
+set SODIUM_PLATFORM=x86
+set CMAKE_GENERATOR="Visual Studio 14 2015"
+call %VCVARSALL% amd64_x86
+if %ERRORLEVEL% NEQ 0 exit 1
+goto download
+
+:download
+REM vcvarsall turns echo off
+echo on
+
+echo Installing libsodium
+set LIBSODIUM_DIR=C:\projects\libsodium
+git clone --branch stable --depth 1 --quiet "https://github.com/jedisct1/libsodium.git" %LIBSODIUM_DIR%
+if %ERRORLEVEL% NEQ 0 (
+  echo cloning libsodium failed
+  exit 1
+)
+
+msbuild /v:minimal /maxcpucount:%NUMBER_OF_PROCESSORS% /p:Configuration=%Configuration%DLL %LIBSODIUM_DIR%\builds\msvc\%MSVCYEAR%\libsodium\libsodium.vcxproj
+if %ERRORLEVEL% NEQ 0 (
+  echo building libsodium failed
+  exit 1
+)
+
+set SODIUM_LIBRARY_DIR="%LIBSODIUM_DIR%\bin\%SODIUM_PLATFORM%\%Configuration%\%MSVCVERSION%\dynamic"
+set SODIUM_INCLUDE_DIR="%LIBSODIUM_DIR%\src\libsodium\include"
+move "%SODIUM_LIBRARY_DIR%\libsodium.lib" "%SODIUM_LIBRARY_DIR%\sodium.lib"
+dir /s %LIBSODIUM_LIBRARY_DIR%
+if %ERRORLEVEL% NEQ 0 exit 1
+
+set PATH=%SODIUM_LIBRARY_DIR%;%PATH%
+
+echo Installing libzmq
+set LIBZMQ_SOURCEDIR=C:\projects\libzmq
+git clone --depth 1 --quiet https://github.com/zeromq/libzmq.git "%LIBZMQ_SOURCEDIR%"
+if %ERRORLEVEL% NEQ 0 (
+  echo cloning libzmq failed
+  exit 1
+)
+
+set LIBZMQ_BUILDDIR=C:\projects\build_libzmq
+md "%LIBZMQ_BUILDDIR%"
+set ORIGINAL_PATH=%CD%
+cd "%LIBZMQ_BUILDDIR%"
+
+cmake -D CMAKE_INCLUDE_PATH="%SODIUM_INCLUDE_DIR%" -D CMAKE_LIBRARY_PATH="%SODIUM_LIBRARY_DIR%" -D CMAKE_CXX_FLAGS_RELEASE="/MT" -D CMAKE_CXX_FLAGS_DEBUG="/MTd" -G %CMAKE_GENERATOR% %LIBZMQ_SOURCEDIR%
+if %ERRORLEVEL% NEQ 0 (
+  echo ...configuring libzmq failed
+  exit 1
+)
+
+msbuild /v:minimal /maxcpucount:%NUMBER_OF_PROCESSORS% /p:Configuration=%Configuration% libzmq.vcxproj
+if %ERRORLEVEL% NEQ 0 (
+  echo ...building libzmq failed
+  exit 1
+)
+
+set LIBZMQ_INCLUDE_DIR=%LIBZMQ_SOURCEDIR%\include
+set LIBZMQ_LIB_DIR=%LIBZMQ_BUILDDIR%\lib\%Configuration%
+dir /s %LIBZMQ_SOURCEDIR%
+move "%LIBZMQ_LIB_DIR%\libzmq-*lib" "%LIBZMQ_LIB_DIR%\zmq.lib"
+set PATH=%LIBZMQ_BUILDDIR%\bin\%Configuration%;%PATH%
+dir /s %LIBZMQ_INCLUDE_DIR%
+dir /s %LIBZMQ_LIB_DIR%
+if %ERRORLEVEL% NEQ 0 exit 1
+
+cd %ORIGINAL_PATH%
+
+set RUST_URL=https://static.rust-lang.org/dist/rust-%RUST%-%TARGET_ARCH%-pc-windows-msvc.msi
+echo Downloading %RUST_URL%...
+mkdir build
+powershell -Command "(New-Object Net.WebClient).DownloadFile('%RUST_URL%', 'build\rust-%RUST%-%TARGET_ARCH%-pc-windows-msvc.msi')"
+if %ERRORLEVEL% NEQ 0 (
+  echo ...downloading Rust failed.
+  exit 1
+)
+
+start /wait msiexec /i build\rust-%RUST%-%TARGET_ARCH%-pc-windows-msvc.msi INSTALLDIR="%TARGET_PROGRAM_FILES%\Rust %RUST%" /quiet /qn /norestart
+if %ERRORLEVEL% NEQ 0 exit 1
+
+set PATH="%TARGET_PROGRAM_FILES%\Rust %RUST%\bin";%PATH%
+
+if [%Configuration%] == [Release] set CARGO_MODE=--release
+
+link /?
+cl /?
+rustc --version
+cargo --version
+
+set RUST_BACKTRACE=1
+
+cargo build -vv %CARGO_MODE%
+if %ERRORLEVEL% NEQ 0 exit 1
+
+cargo test -vv %CARGO_MODE%
+if %ERRORLEVEL% NEQ 0 exit 1

--- a/.appveyor/appveyor.bat
+++ b/.appveyor/appveyor.bat
@@ -56,7 +56,7 @@ set PATH=%SODIUM_LIBRARY_DIR%;%PATH%
 
 echo Installing libzmq
 set LIBZMQ_SOURCEDIR=C:\projects\libzmq
-git clone --depth 1 --quiet https://github.com/zeromq/libzmq.git "%LIBZMQ_SOURCEDIR%"
+git clone --branch v4.2.0 --depth 1 --quiet https://github.com/zeromq/libzmq.git "%LIBZMQ_SOURCEDIR%"
 if %ERRORLEVEL% NEQ 0 (
   echo cloning libzmq failed
   exit 1

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -95,3 +95,4 @@ zmq-sys = { version = "0.8.0", path = "zmq-sys" }
 quickcheck = "0.4.0"
 rand = "*"
 tempfile = "*"
+timebomb = "0.1.2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -68,6 +68,8 @@ path = "examples/zguide/weather_server/main.rs"
 
 [features]
 unstable = []
+default = ["zmq_has"]
+zmq_has = [] # zmq_has was added in zeromq 4.1.
 unstable-testing = ["compiletest_rs", "unstable"]
 #unstable-testing = ["clippy", "compiletest_rs", "unstable"]
 
@@ -87,7 +89,6 @@ compiletest_rs = { version = "0.*", optional = true }
 clippy = { version = "0.*", optional = true }
 
 [build-dependencies]
-libc = "0.2.15"
 zmq-sys = { version = "0.8.0", path = "zmq-sys" }
 
 [dev-dependencies]

--- a/build.rs
+++ b/build.rs
@@ -1,14 +1,25 @@
-use std::mem::size_of;
-use std::os::raw::c_int;
-
-extern crate libc;
 extern crate zmq_sys as zmq;
 
-const ZMQ_CURVE_SERVER: c_int = 47;
-const ZMQ_GSSAPI_SERVER: c_int = 62;
-const ZMQ_REQ: c_int = 3;
-
+#[cfg(feature = "zmq_has")]
 fn main() {
+    use std::ffi::CString;
+
+	for has in ["ipc", "pgm", "tipc", "norm", "curve", "gssapi"].into_iter() {
+		if unsafe { zmq::zmq_has(CString::new(has.as_bytes()).unwrap().as_ptr()) } == 1 {
+			println!("cargo:rustc-cfg=ZMQ_HAS_{}=\"1\"", has.to_uppercase());
+		}
+	}
+}
+
+#[cfg(not(feature = "zmq_has"))]
+fn main() {
+    use std::mem::size_of;
+    use std::os::raw::c_int;
+
+    const ZMQ_CURVE_SERVER: c_int = 47;
+    const ZMQ_GSSAPI_SERVER: c_int = 62;
+    const ZMQ_REQ: c_int = 3;
+
     // As long as we support pre-4.1 versions of libzmq, we can't use zmq_has()
     // here because that would make the build script fail to link.
     //
@@ -27,7 +38,7 @@ fn main() {
             let rc = zmq::zmq_setsockopt(sock, opt, &mut one as *mut c_int as *mut _,
                                          size_of::<c_int>());
             if rc == -1 {
-                assert!(zmq::zmq_errno() == libc::EINVAL);
+                assert!(zmq::zmq_errno() == zmq::errno::EINVAL);
             } else {
                 println!("cargo:rustc-cfg=ZMQ_HAS_{}=\"1\"", feature.to_uppercase());
             }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -22,6 +22,8 @@ use std::string::FromUtf8Error;
 use std::{mem, ptr, str, slice};
 use std::sync::Arc;
 
+use zmq_sys::errno;
+
 macro_rules! zmq_try {
     ($($tt:tt)*) => {{
         let rc = $($tt)*;
@@ -217,41 +219,40 @@ pub enum Mechanism {
 
 impl Copy for Mechanism {}
 
-const ZMQ_HAUSNUMERO: isize = 156384712;
 
 /// An error returned by a 0MQ API function.
 #[derive(Clone, Eq, PartialEq)]
 pub enum Error {
-    EACCES          = libc::EACCES as isize,
-    EADDRINUSE      = libc::EADDRINUSE as isize,
-    EAGAIN          = libc::EAGAIN as isize,
-    EBUSY           = libc::EBUSY as isize,
-    ECONNREFUSED    = libc::ECONNREFUSED as isize,
-    EFAULT          = libc::EFAULT as isize,
-    EINTR           = libc::EINTR as isize,
-    EHOSTUNREACH    = libc::EHOSTUNREACH as isize,
-    EINPROGRESS     = libc::EINPROGRESS as isize,
-    EINVAL          = libc::EINVAL as isize,
-    EMFILE          = libc::EMFILE as isize,
-    EMSGSIZE        = libc::EMSGSIZE as isize,
-    ENAMETOOLONG    = libc::ENAMETOOLONG as isize,
-    ENODEV          = libc::ENODEV as isize,
-    ENOENT          = libc::ENOENT as isize,
-    ENOMEM          = libc::ENOMEM as isize,
-    ENOTCONN        = libc::ENOTCONN as isize,
-    ENOTSOCK        = libc::ENOTSOCK as isize,
-    EPROTO          = libc::EPROTO as isize,
-    EPROTONOSUPPORT = libc::EPROTONOSUPPORT as isize,
-    ENOTSUP         = (ZMQ_HAUSNUMERO + 1) as isize,
-    ENOBUFS         = (ZMQ_HAUSNUMERO + 3) as isize,
-    ENETDOWN        = (ZMQ_HAUSNUMERO + 4) as isize,
-    EADDRNOTAVAIL   = (ZMQ_HAUSNUMERO + 6) as isize,
+    EACCES          = errno::EACCES as isize,
+    EADDRINUSE      = errno::EADDRINUSE as isize,
+    EAGAIN          = errno::EAGAIN as isize,
+    EBUSY           = errno::EBUSY as isize,
+    ECONNREFUSED    = errno::ECONNREFUSED as isize,
+    EFAULT          = errno::EFAULT as isize,
+    EINTR           = errno::EINTR as isize,
+    EHOSTUNREACH    = errno::EHOSTUNREACH as isize,
+    EINPROGRESS     = errno::EINPROGRESS as isize,
+    EINVAL          = errno::EINVAL as isize,
+    EMFILE          = errno::EMFILE as isize,
+    EMSGSIZE        = errno::EMSGSIZE as isize,
+    ENAMETOOLONG    = errno::ENAMETOOLONG as isize,
+    ENODEV          = errno::ENODEV as isize,
+    ENOENT          = errno::ENOENT as isize,
+    ENOMEM          = errno::ENOMEM as isize,
+    ENOTCONN        = errno::ENOTCONN as isize,
+    ENOTSOCK        = errno::ENOTSOCK as isize,
+    EPROTO          = errno::EPROTO as isize,
+    EPROTONOSUPPORT = errno::EPROTONOSUPPORT as isize,
+    ENOTSUP         = errno::ENOTSUP as isize,
+    ENOBUFS         = errno::ENOBUFS as isize,
+    ENETDOWN        = errno::ENETDOWN as isize,
+    EADDRNOTAVAIL   = errno::EADDRNOTAVAIL as isize,
 
     // native zmq error codes
-    EFSM            = (ZMQ_HAUSNUMERO + 51) as isize,
-    ENOCOMPATPROTO  = (ZMQ_HAUSNUMERO + 52) as isize,
-    ETERM           = (ZMQ_HAUSNUMERO + 53) as isize,
-    EMTHREAD        = (ZMQ_HAUSNUMERO + 54) as isize,
+    EFSM            = errno::EFSM as isize,
+    ENOCOMPATPROTO  = errno::ENOCOMPATPROTO as isize,
+    ETERM           = errno::ETERM as isize,
+    EMTHREAD        = errno::EMTHREAD as isize,
 }
 
 impl Copy for Error {}
@@ -264,26 +265,29 @@ impl Error {
     pub fn from_raw(raw: i32) -> Error {
         #![cfg_attr(feature = "clippy", allow(match_same_arms))]
         match raw {
-            libc::EACCES             => Error::EACCES,
-            libc::EADDRINUSE         => Error::EADDRINUSE,
-            libc::EAGAIN             => Error::EAGAIN,
-            libc::EBUSY              => Error::EBUSY,
-            libc::ECONNREFUSED       => Error::ECONNREFUSED,
-            libc::EFAULT             => Error::EFAULT,
-            libc::EHOSTUNREACH       => Error::EHOSTUNREACH,
-            libc::EINPROGRESS        => Error::EINPROGRESS,
-            libc::EINVAL             => Error::EINVAL,
-            libc::EMFILE             => Error::EMFILE,
-            libc::EMSGSIZE           => Error::EMSGSIZE,
-            libc::ENAMETOOLONG       => Error::ENAMETOOLONG,
-            libc::ENODEV             => Error::ENODEV,
-            libc::ENOENT             => Error::ENOENT,
-            libc::ENOMEM             => Error::ENOMEM,
-            libc::ENOTCONN           => Error::ENOTCONN,
-            libc::ENOTSOCK           => Error::ENOTSOCK,
-            libc::EPROTO             => Error::EPROTO,
-            libc::EPROTONOSUPPORT    => Error::EPROTONOSUPPORT,
-            156384713                => Error::ENOTSUP,
+            errno::EACCES             => Error::EACCES,
+            errno::EADDRINUSE         => Error::EADDRINUSE,
+            errno::EAGAIN             => Error::EAGAIN,
+            errno::EBUSY              => Error::EBUSY,
+            errno::ECONNREFUSED       => Error::ECONNREFUSED,
+            errno::EFAULT             => Error::EFAULT,
+            errno::EHOSTUNREACH       => Error::EHOSTUNREACH,
+            errno::EINPROGRESS        => Error::EINPROGRESS,
+            errno::EINVAL             => Error::EINVAL,
+            errno::EMFILE             => Error::EMFILE,
+            errno::EMSGSIZE           => Error::EMSGSIZE,
+            errno::ENAMETOOLONG       => Error::ENAMETOOLONG,
+            errno::ENODEV             => Error::ENODEV,
+            errno::ENOENT             => Error::ENOENT,
+            errno::ENOMEM             => Error::ENOMEM,
+            errno::ENOTCONN           => Error::ENOTCONN,
+            errno::ENOTSOCK           => Error::ENOTSOCK,
+            errno::EPROTO             => Error::EPROTO,
+            errno::EPROTONOSUPPORT    => Error::EPROTONOSUPPORT,
+            errno::ENOTSUP            => Error::ENOTSUP,
+            errno::ENOBUFS            => Error::ENOBUFS,
+            errno::ENETDOWN           => Error::ENETDOWN,
+            errno::EADDRNOTAVAIL      => Error::EADDRNOTAVAIL,
             156384714                => Error::EPROTONOSUPPORT,
             156384715                => Error::ENOBUFS,
             156384716                => Error::ENETDOWN,

--- a/tests/shared-context.rs
+++ b/tests/shared-context.rs
@@ -1,16 +1,22 @@
+extern crate timebomb;
 extern crate zmq;
 
 use std::thread;
 use std::str;
+use timebomb::timeout_ms;
 
 #[test]
 fn test_inproc() {
-    shared_context("inproc://pub");
+    timeout_ms(|| {
+        shared_context("inproc://pub");
+    }, 10000);
 }
 
 #[test]
 fn test_tcp() {
-    shared_context("tcp://127.0.0.1:*");
+    timeout_ms(|| {
+        shared_context("tcp://127.0.0.1:*");
+    }, 10000);
 }
 
 fn shared_context(address: &str) {

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -8,6 +8,12 @@ fn create_socketpair() -> (Socket, Socket) {
     let sender = ctx.socket(zmq::REQ).unwrap();
     let receiver = ctx.socket(zmq::REP).unwrap();
 
+    // Don't block forever
+    sender.set_sndtimeo(1000).unwrap();
+    sender.set_rcvtimeo(1000).unwrap();
+    receiver.set_sndtimeo(1000).unwrap();
+    receiver.set_rcvtimeo(1000).unwrap();
+
     receiver.bind("tcp://*:*").unwrap();
     let ep = receiver.get_last_endpoint().unwrap().unwrap();
     sender.connect(&ep).unwrap();

--- a/zmq-sys/Cargo.toml
+++ b/zmq-sys/Cargo.toml
@@ -9,7 +9,7 @@ license = "MIT/Apache-2.0"
 description = "Low-level bindings to the zeromq library"
 repository = "https://github.com/erickt/rust-zmq"
 build = "build.rs"
-links = "libzmq"
+links = "zmq"
 
 [dependencies]
 libc = "0.2.15"

--- a/zmq-sys/build.rs
+++ b/zmq-sys/build.rs
@@ -3,13 +3,32 @@ extern crate pkg_config;
 use std::env;
 
 fn main() {
-    if let Some(prefix) = env::var("LIBZMQ_PREFIX").ok() {
-        println!("cargo:rustc-link-search=native={}/lib", prefix);
-        println!("cargo:include={}/include", prefix);
-    } else {
-        match pkg_config::find_library("libzmq") {
-            Ok(pkg) => println!("{:?}", pkg),
-            Err(e) => panic!("Unable to locate libzmq, err={:?}", e),
+    let lib_path = env::var("LIBZMQ_LIB_DIR").ok().or_else(|| {
+        env::var("LIBZMQ_PREFIX").ok()
+            .map(|prefix| format!("{}/lib", prefix))
+    });
+
+    let include = env::var("LIBZMQ_INCLUDE_DIR").ok().or_else(|| {
+        env::var("LIBZMQ_PREFIX").ok()
+            .map(|prefix| format!("{}/include", prefix))
+    });
+
+    match (lib_path, include) {
+        (Some(lib_path), Some(include)) => {
+            println!("cargo:rustc-link-search=native={}", lib_path);
+            println!("cargo:include={}", include);
+        }
+        (Some(_), None) => {
+            panic!("Unable to locate libzmq include directory.")
+        }
+        (None, Some(_)) => {
+            panic!("Unable to locate libzmq library directory.")
+        }
+        (None, None) => {
+            match pkg_config::probe_library("libzmq") {
+                Ok(pkg) => println!("{:?}", pkg),
+                Err(e) => panic!("Unable to locate libzmq, err={:?}", e),
+            }
         }
     }
 }

--- a/zmq-sys/src/errno.rs
+++ b/zmq-sys/src/errno.rs
@@ -1,0 +1,44 @@
+
+#[cfg(target_os = "windows")]
+use win_errno as errno;
+
+#[cfg(not(target_os = "windows"))]
+use libc as errno;
+
+const ZMQ_HAUSNUMERO: i32 = 156384712;
+
+pub const EACCES:           i32 = errno::EACCES;
+pub const EADDRINUSE:       i32 = errno::EADDRINUSE;
+pub const EAGAIN:           i32 = errno::EAGAIN;
+pub const EBUSY:            i32 = errno::EBUSY;
+pub const ECONNREFUSED:     i32 = errno::ECONNREFUSED;
+pub const EFAULT:           i32 = errno::EFAULT;
+pub const EINTR:            i32 = errno::EINTR;
+pub const EHOSTUNREACH:     i32 = errno::EHOSTUNREACH;
+pub const EINPROGRESS:      i32 = errno::EINPROGRESS;
+pub const EINVAL:           i32 = errno::EINVAL;
+pub const EMFILE:           i32 = errno::EMFILE;
+pub const EMSGSIZE:         i32 = errno::EMSGSIZE;
+pub const ENAMETOOLONG:     i32 = errno::ENAMETOOLONG;
+pub const ENODEV:           i32 = errno::ENODEV;
+pub const ENOENT:           i32 = errno::ENOENT;
+pub const ENOMEM:           i32 = errno::ENOMEM;
+pub const ENOTCONN:         i32 = errno::ENOTCONN;
+pub const ENOTSOCK:         i32 = errno::ENOTSOCK;
+pub const EPROTO:           i32 = errno::EPROTO;
+pub const EPROTONOSUPPORT:  i32 = errno::EPROTONOSUPPORT;
+
+#[cfg(not(target_os = "windows"))]
+pub const ENOTSUP:          i32 = (ZMQ_HAUSNUMERO + 1);
+#[cfg(target_os = "windows")]
+pub const ENOTSUP:          i32 = errno::ENOTSUP;
+
+pub const ENOBUFS:          i32 = errno::ENOBUFS;
+pub const ENETDOWN:         i32 = errno::ENETDOWN;
+pub const EADDRNOTAVAIL:    i32 = errno::EADDRNOTAVAIL;
+
+// native zmq error codes
+pub const EFSM:             i32 = (ZMQ_HAUSNUMERO + 51);
+pub const ENOCOMPATPROTO:   i32 = (ZMQ_HAUSNUMERO + 52);
+pub const ETERM:            i32 = (ZMQ_HAUSNUMERO + 53);
+pub const EMTHREAD:         i32 = (ZMQ_HAUSNUMERO + 54);

--- a/zmq-sys/src/lib.rs
+++ b/zmq-sys/src/lib.rs
@@ -1,6 +1,11 @@
 
 extern crate libc;
 
+#[cfg(target_os = "windows")]
+mod win_errno;
+
+pub mod errno;
+
 pub use ffi::{
     zmq_msg_t,
     zmq_free_fn,

--- a/zmq-sys/src/win_errno.rs
+++ b/zmq-sys/src/win_errno.rs
@@ -1,0 +1,28 @@
+use libc::c_int;
+
+// Use constants as defined in the windows header errno.h
+// libzmq should be compiled with VS2010 SDK headers or newer
+pub const EACCES: c_int = 13;
+pub const EADDRINUSE: c_int = 100;
+pub const EADDRNOTAVAIL: c_int = 101;
+pub const EAGAIN: c_int = 11;
+pub const EBUSY: c_int = 16;
+pub const ECONNREFUSED: c_int = 107;
+pub const EFAULT: c_int = 14;
+pub const EINTR: c_int = 4;
+pub const EHOSTUNREACH: c_int = 110;
+pub const EINPROGRESS: c_int = 112;
+pub const EINVAL: c_int = 22;
+pub const EMFILE: c_int = 24;
+pub const EMSGSIZE: c_int = 115;
+pub const ENAMETOOLONG: c_int = 38;
+pub const ENETDOWN: c_int = 116;
+pub const ENOBUFS: c_int = 119;
+pub const ENODEV: c_int = 19;
+pub const ENOENT: c_int = 2;
+pub const ENOMEM: c_int = 12;
+pub const ENOTCONN: c_int = 126;
+pub const ENOTSOCK: c_int = 128;
+pub const ENOTSUP: c_int = 129;
+pub const EPROTO: c_int = 134;
+pub const EPROTONOSUPPORT: c_int = 135;


### PR DESCRIPTION
This fixes appveyor integration with zeromq. It also merges in @tcosprojects's #94 windows fixes, which gets most, but not all, tests to pass on appveyor. The current output can be seen [here](https://ci.appveyor.com/project/erickt/rust-zmq/build/1.0.147). Specifically the tests that fail are:

```
failures:
    test_exchanging_bytes
    test_exchanging_messages
    test_exchanging_multipart
    test_exchanging_strings
    test_polling
```

I'm fine landing this in this current state, we can fix these test failures in a future patch.