### PR TITLE
Bump version to 0.9.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zmq"
-version = "0.8.0"
+version = "0.9.0"
 authors = [
     "a.rottmann@gmx.at",
     "erick.tryzelaar@gmail.com",
@@ -84,12 +84,12 @@ path = "examples/zguide/fileio3/main.rs"
 [dependencies]
 libc = "0.2.15"
 log = "0.3.6"
-zmq-sys = { version = "0.8.0", path = "zmq-sys" }
+zmq-sys = { version = "0.9.0", path = "zmq-sys" }
 compiletest_rs = { version = "0.*", optional = true }
 clippy = { version = "0.*", optional = true }
 
 [build-dependencies]
-zmq-sys = { version = "0.8.0", path = "zmq-sys" }
+zmq-sys = { version = "0.9.0", path = "zmq-sys" }
 
 [dev-dependencies]
 quickcheck = "0.4.0"

--- a/zmq-sys/Cargo.toml
+++ b/zmq-sys/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zmq-sys"
-version = "0.8.0"
+version = "0.9.0"
 authors = [
     "a.rottmann@gmx.at",
     "erick.tryzelaar@gmail.com",


### PR DESCRIPTION
The master branch is now headed towards a new, API-incompatible
release, hence the bump to 0.9.