### PR TITLE
	Make message allocation infallible, and reap some benefits

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -7,13 +7,23 @@ documentation.
 
 - The deprecated `Constants` enum has been removed from the API.
 
+- Message allocation, e.g. `Message::new()` directly returns `Message`
+  instead of `Result<Message>` and will panic on allocation failure,
+  as is customary in Rust. Reported in #118 and fixed by #130.
+
 ## New and improved functionality
 
-None yet.
+- `Message` now implements `From` for various types that have an
+  obvious byte-level representation. This is possible due to the
+  message allocation API change (see above).
+
+- `Message::send()` now works on `Into<Message>` types, obsoleting
+  `send_msg()` and `send_str()`.
 
 ## Deprecations
 
-None yet.
+- `Message::send_msg()` and `send_str()` are deprecated in favor of
+  `Message::send()`.
 
 # 0.8.0
 

--- a/examples/msgsend/main.rs
+++ b/examples/msgsend/main.rs
@@ -15,7 +15,7 @@ use std::sync::mpsc::{channel, Sender, Receiver};
 
 fn server(pull_socket: zmq::Socket, push_socket: zmq::Socket, mut workers: u64) {
     let mut count = 0;
-    let mut msg = zmq::Message::new().unwrap();
+    let mut msg = zmq::Message::new();
 
     while workers != 0 {
         pull_socket.recv(&mut msg, 0).unwrap();
@@ -27,7 +27,7 @@ fn server(pull_socket: zmq::Socket, push_socket: zmq::Socket, mut workers: u64) 
         }
     }
 
-    push_socket.send_str(&count.to_string(), 0).unwrap();
+    push_socket.send(&count.to_string(), 0).unwrap();
 }
 
 fn spawn_server(ctx: &mut zmq::Context, workers: u64) -> Sender<()> {
@@ -59,11 +59,11 @@ fn spawn_server(ctx: &mut zmq::Context, workers: u64) -> Sender<()> {
 
 fn worker(push_socket: zmq::Socket, count: u64) {
     for _ in 0 .. count {
-        push_socket.send_str(&100.to_string(), 0).unwrap();
+        push_socket.send(&100.to_string(), 0).unwrap();
     }
 
     // Let the server know we're done.
-    push_socket.send_str("", 0).unwrap();
+    push_socket.send("", 0).unwrap();
 }
 
 fn spawn_worker(ctx: &mut zmq::Context, count: u64) -> Receiver<()> {

--- a/examples/zguide/fileio3/main.rs
+++ b/examples/zguide/fileio3/main.rs
@@ -44,9 +44,9 @@ fn client_thread(expected_total: usize) {
     loop {
         while (credit > 0) && !clean_break {
             // Ask for next chunk
-            dealer.send_str("fetch", SNDMORE).unwrap();
-            dealer.send_str(&offset.to_string(), SNDMORE).unwrap();
-            dealer.send_str(CHUNK_SIZE_STR, 0).unwrap();
+            dealer.send("fetch", SNDMORE).unwrap();
+            dealer.send(&offset.to_string(), SNDMORE).unwrap();
+            dealer.send(CHUNK_SIZE_STR, 0).unwrap();
             offset += CHUNK_SIZE;
             credit -= 1;
         }

--- a/examples/zguide/helloworld_client/main.rs
+++ b/examples/zguide/helloworld_client/main.rs
@@ -12,11 +12,11 @@ fn main() {
 
     assert!(requester.connect("tcp://localhost:5555").is_ok());
 
-    let mut msg = zmq::Message::new().unwrap();
+    let mut msg = zmq::Message::new();
 
     for request_nbr in 0..10 {
         println!("Sending Hello {}...", request_nbr);
-        requester.send(b"Hello", 0).unwrap();
+        requester.send("Hello", 0).unwrap();
 
         requester.recv(&mut msg, 0).unwrap();
         println!("Received World {}: {}", msg.as_str().unwrap(), request_nbr);

--- a/examples/zguide/helloworld_server/main.rs
+++ b/examples/zguide/helloworld_server/main.rs
@@ -15,11 +15,11 @@ fn main() {
 
     assert!(responder.bind("tcp://*:5555").is_ok());
 
-    let mut msg = zmq::Message::new().unwrap();
+    let mut msg = zmq::Message::new();
     loop {
         responder.recv(&mut msg, 0).unwrap();
         println!("Received {}", msg.as_str().unwrap());
         thread::sleep(Duration::from_millis(1000));
-        responder.send_str("World", 0).unwrap();
+        responder.send("World", 0).unwrap();
     }
 }

--- a/examples/zguide/lvcache/main.rs
+++ b/examples/zguide/lvcache/main.rs
@@ -29,8 +29,8 @@ fn main() {
             let topic = frontend.recv_msg(0).unwrap();
             let current = frontend.recv_msg(0).unwrap();
             cache.insert(topic.to_vec(), current.to_vec());
-            backend.send_msg(topic, zmq::SNDMORE).unwrap();
-            backend.send_msg(current, 0).unwrap();
+            backend.send(topic, zmq::SNDMORE).unwrap();
+            backend.send(current, 0).unwrap();
         }
         if (items[1].get_revents() & zmq::POLLIN) != 0 {
             // Event is one byte 0=unsub or 1=sub, followed by topic

--- a/examples/zguide/msreader/main.rs
+++ b/examples/zguide/msreader/main.rs
@@ -24,7 +24,7 @@ fn main() {
 
     // Process messages from both sockets
     // We prioritize traffic from the task ventilator
-    let mut msg = zmq::Message::new().unwrap();
+    let mut msg = zmq::Message::new();
     loop {
         loop {
             if let Err(_) = receiver.recv(&mut msg, zmq::DONTWAIT) {

--- a/examples/zguide/pathopub/main.rs
+++ b/examples/zguide/pathopub/main.rs
@@ -21,15 +21,15 @@ fn main() {
 
     // Send out all 1,000 topic messages
     for topic_nbr in 0..1000  {
-        publisher.send_str(&format!("{:03}", topic_nbr), zmq::SNDMORE).unwrap();
-        publisher.send_str("Save Roger", 0).unwrap();
+        publisher.send(&format!("{:03}", topic_nbr), zmq::SNDMORE).unwrap();
+        publisher.send("Save Roger", 0).unwrap();
     }
     // Send one random update per second
     let mut rng = rand::thread_rng();
     let topic_range = Range::new(0, 1000);
     loop {
         sleep(Duration::from_millis(1000));
-        publisher.send_str(&format!("{:03}", topic_range.ind_sample(&mut rng)), zmq::SNDMORE).unwrap();
-        publisher.send_str("Off with his head!", 0).unwrap();
+        publisher.send(&format!("{:03}", topic_range.ind_sample(&mut rng)), zmq::SNDMORE).unwrap();
+        publisher.send("Off with his head!", 0).unwrap();
     }
 }

--- a/examples/zguide/rtdealer/main.rs
+++ b/examples/zguide/rtdealer/main.rs
@@ -26,8 +26,8 @@ fn worker_task() {
     let mut total = 0;
     loop {
         // Tell the broker we're ready for work
-        worker.send(b"", SNDMORE).unwrap();
-        worker.send_str("Hi boss!", 0).unwrap();
+        worker.send("", SNDMORE).unwrap();
+        worker.send("Hi boss!", 0).unwrap();
 
         // Get workload from broker, until finished
         worker.recv_bytes(0).unwrap();  // envelope delimiter
@@ -72,13 +72,13 @@ fn main() {
 
         broker.recv_bytes(0).unwrap(); // Envelope
         broker.recv_bytes(0).unwrap(); // Response from worker
-        broker.send(b"", SNDMORE).unwrap();
+        broker.send("", SNDMORE).unwrap();
 
         // Encourage workers until it's time to fire them
         if start_time.elapsed() < allowed_duration {
-            broker.send_str("Work harder", 0).unwrap();
+            broker.send("Work harder", 0).unwrap();
         } else {
-            broker.send_str("Fired!", 0).unwrap();
+            broker.send("Fired!", 0).unwrap();
             workers_fired += 1;
             if workers_fired >= worker_pool_size {
                 break;

--- a/examples/zguide/taskvent/main.rs
+++ b/examples/zguide/taskvent/main.rs
@@ -27,7 +27,7 @@ fn main() {
 
     println!("Sending tasks to workers...");
     //  The first message is "0" and signals start of batch
-    sink.send(b"0", 0).unwrap();
+    sink.send("0", 0).unwrap();
 
     let mut rng = rand::thread_rng();
 
@@ -40,7 +40,7 @@ fn main() {
         total_msec += workload;
 
         let workload_str = format!("{}", workload);
-        sender.send_str(&workload_str, 0).unwrap();
+        sender.send(&workload_str, 0).unwrap();
      }
 
     println!("Total expected cost: {} msec", total_msec)

--- a/examples/zguide/taskwork/main.rs
+++ b/examples/zguide/taskwork/main.rs
@@ -38,7 +38,7 @@ fn main() {
         thread::sleep(Duration::from_millis(atoi(&string)));
 
         // Send results to sink
-        sender.send(b"", 0).unwrap();
+        sender.send("", 0).unwrap();
      }
 
 }

--- a/examples/zguide/weather_server/main.rs
+++ b/examples/zguide/weather_server/main.rs
@@ -27,7 +27,7 @@ fn main() {
         // very, very slow. Several orders of magnitude slower than glibc's
         // sprintf
         let update = format!("{:05} {} {}", zipcode, temperature, relhumidity);
-        publisher.send_str(&update, 0).unwrap();
+        publisher.send(&update, 0).unwrap();
     }
 
     // note: destructors mean no explicit cleanup necessary

--- a/tests/compile-fail/socket-thread-unsafe.rs
+++ b/tests/compile-fail/socket-thread-unsafe.rs
@@ -15,6 +15,6 @@ fn main() {
     let t = thread::spawn(move || {  //~ ERROR he trait bound `*mut std::os::raw::c_void: std::marker::Sync` is not satisfied [E0277]
         t!(s.bind("tcp://127.0.0.1:12345"))
     });
-    socket.send(b"ABC", 0);
+    socket.send("ABC", 0);
     t.join().unwrap();
 }

--- a/tests/shared-context.rs
+++ b/tests/shared-context.rs
@@ -27,7 +27,7 @@ fn shared_context(address: &str) {
     let endpoint = push_socket.get_last_endpoint().unwrap().unwrap();
     let worker1 = fork(&ctx, endpoint);
 
-    push_socket.send(b"Message1", 0).unwrap();
+    push_socket.send("Message1", 0).unwrap();
 
     worker1.join().unwrap();
 }


### PR DESCRIPTION
This fixes #118, and allows for implementation of the `From<&[u8]>`
and `From<Vec<u8>` for `Message`.