### PR TITLE
Make curve key and identity accessors operate on binary data

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -717,9 +717,9 @@ impl Socket {
         (_, set_unsubscribe) => ZMQ_UNSUBSCRIBE as &[u8],
     }
 
-    pub fn get_identity(&self) -> Result<result::Result<String, Vec<u8>>> {
+    pub fn get_identity(&self) -> Result<Vec<u8>> {
         // 255 = identity max length
-        sockopt::get_string(self.sock, Constants::ZMQ_IDENTITY.to_raw(), 255, false)
+        sockopt::get_bytes(self.sock, Constants::ZMQ_IDENTITY.to_raw(), 255)
     }
 
     pub fn get_socks_proxy(&self) -> Result<result::Result<String, Vec<u8>>> {
@@ -761,24 +761,34 @@ impl Socket {
     }
 
     #[cfg(ZMQ_HAS_CURVE = "1")]
-    // FIXME: there should be no decoding errors, hence the return type can be simplified
-    pub fn get_curve_publickey(&self) -> Result<result::Result<String, Vec<u8>>> {
-        // 41 = Z85 encoded keysize + 1 for null byte
-        sockopt::get_string(self.sock, Constants::ZMQ_CURVE_PUBLICKEY.to_raw(), 41, true)
+    /// Set the `ZMQ_CURVE_PUBLICKEY` option value.
+    ///
+    /// The key is returned as raw bytes. Use `z85_encode` on the
+    /// resulting data to get the Z85-encoded string representation of
+    /// the key.
+    pub fn get_curve_publickey(&self) -> Result<Vec<u8>> {
+        sockopt::get_bytes(self.sock, Constants::ZMQ_CURVE_PUBLICKEY.to_raw(), 32)
     }
 
     #[cfg(ZMQ_HAS_CURVE = "1")]
-    // FIXME: there should be no decoding errors, hence the return type can be simplified
-    pub fn get_curve_secretkey(&self) -> Result<result::Result<String, Vec<u8>>> {
-        // 41 = Z85 encoded keysize + 1 for null byte
-        sockopt::get_string(self.sock, Constants::ZMQ_CURVE_SECRETKEY.to_raw(), 41, true)
+    /// Get the `ZMQ_CURVE_SECRETKEY` option value.
+    ///
+    /// The key is returned as raw bytes. Use `z85_encode` on the
+    /// resulting data to get the Z85-encoded string representation of
+    /// the key.
+    pub fn get_curve_secretkey(&self) -> Result<Vec<u8>> {
+        sockopt::get_bytes(self.sock, Constants::ZMQ_CURVE_SECRETKEY.to_raw(), 32)
     }
 
+    /// Get `ZMQ_CURVE_SERVERKEY` option value.
+    ///
+    /// Note that the key is returned as raw bytes, as a 32-byte
+    /// vector. Use `z85_encode()` explicitly to obtain the
+    /// Z85-encoded string variant.
     #[cfg(ZMQ_HAS_CURVE = "1")]
-    // FIXME: there should be no decoding errors, hence the return type can be simplified
-    pub fn get_curve_serverkey(&self) -> Result<result::Result<String, Vec<u8>>> {
+    pub fn get_curve_serverkey(&self) -> Result<Vec<u8>> {
         // 41 = Z85 encoded keysize + 1 for null byte
-        sockopt::get_string(self.sock, Constants::ZMQ_CURVE_SERVERKEY.to_raw(), 41, true)
+        sockopt::get_bytes(self.sock, Constants::ZMQ_CURVE_SERVERKEY.to_raw(), 32)
     }
 
     #[cfg(ZMQ_HAS_GSSAPI = "1")]
@@ -800,9 +810,9 @@ impl Socket {
         (_, set_zap_domain) => ZMQ_ZAP_DOMAIN as &str,
 
         if ZMQ_HAS_CURVE {
-            (_, set_curve_publickey) => ZMQ_CURVE_PUBLICKEY as &str,
-            (_, set_curve_secretkey) => ZMQ_CURVE_SECRETKEY as &str,
-            (_, set_curve_serverkey) => ZMQ_CURVE_SERVERKEY as &str,
+            (_, set_curve_publickey) => ZMQ_CURVE_PUBLICKEY as &[u8],
+            (_, set_curve_secretkey) => ZMQ_CURVE_SECRETKEY as &[u8],
+            (_, set_curve_serverkey) => ZMQ_CURVE_SERVERKEY as &[u8],
         },
         if ZMQ_HAS_GSSAPI {
             (_, set_gssapi_principal) => ZMQ_GSSAPI_PRINCIPAL as &str,

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -213,7 +213,7 @@ test!(test_getset_identity, {
     let ctx = Context::new();
     let sock = ctx.socket(REQ).unwrap();
     sock.set_identity(b"moo").unwrap();
-    assert_eq!(sock.get_identity().unwrap().unwrap(), "moo");
+    assert_eq!(sock.get_identity().unwrap(), b"moo");
 });
 
 test!(test_subscription, {
@@ -453,24 +453,27 @@ test!(test_getset_curve_server, {
 test!(test_getset_curve_publickey, {
     let ctx = Context::new();
     let sock = ctx.socket(REQ).unwrap();
-    sock.set_curve_publickey("FX5b8g5ZnOk7$Q}^)Y&?.v3&MIe+]OU7DTKynkUL").unwrap();
-    assert_eq!(sock.get_curve_publickey().unwrap().unwrap(), "FX5b8g5ZnOk7$Q}^)Y&?.v3&MIe+]OU7DTKynkUL");
+    let key = z85_decode("FX5b8g5ZnOk7$Q}^)Y&?.v3&MIe+]OU7DTKynkUL").unwrap();
+    sock.set_curve_publickey(&key).unwrap();
+    assert_eq!(sock.get_curve_publickey().unwrap(), key);
 });
 
 #[cfg(ZMQ_HAS_CURVE = "1")]
 test!(test_getset_curve_secretkey, {
     let ctx = Context::new();
     let sock = ctx.socket(REQ).unwrap();
-    sock.set_curve_secretkey("s9N%S3*NKSU$6pUnpBI&K5HBd[]G$Y3yrK?mhdbS").unwrap();
-    assert_eq!(sock.get_curve_secretkey().unwrap().unwrap(), "s9N%S3*NKSU$6pUnpBI&K5HBd[]G$Y3yrK?mhdbS");
+    let key = z85_decode("s9N%S3*NKSU$6pUnpBI&K5HBd[]G$Y3yrK?mhdbS").unwrap();
+    sock.set_curve_secretkey(&key).unwrap();
+    assert_eq!(sock.get_curve_secretkey().unwrap(), key);
 });
 
 #[cfg(ZMQ_HAS_CURVE = "1")]
 test!(test_getset_curve_serverkey, {
     let ctx = Context::new();
     let sock = ctx.socket(REQ).unwrap();
-    sock.set_curve_serverkey("FX5b8g5ZnOk7$Q}^)Y&?.v3&MIe+]OU7DTKynkUL").unwrap();
-    assert_eq!(sock.get_curve_serverkey().unwrap().unwrap(), "FX5b8g5ZnOk7$Q}^)Y&?.v3&MIe+]OU7DTKynkUL");
+    let key = z85_decode("FX5b8g5ZnOk7$Q}^)Y&?.v3&MIe+]OU7DTKynkUL").unwrap();
+    sock.set_curve_serverkey(&key).unwrap();
+    assert_eq!(sock.get_curve_serverkey().unwrap(), key);
 });
 
 test!(test_getset_conflate, {


### PR DESCRIPTION
This has been re-applied based on commit 1804c88, now that the 0.8
release is out of the way.

The change to make `get_fd()` return `RawFd`, which was part of that
commit, has not been included, as this would fail compilation on
Windows.