### PR TITLE
Fix connect()-related Appveyor/win test failures

### DIFF
--- a/tests/test.rs
+++ b/tests/test.rs
@@ -5,6 +5,17 @@ use std::net::TcpStream;
 use timebomb::timeout_ms;
 use zmq::*;
 
+#[cfg(not(target_os = "windows"))]
+#[inline]
+fn get_endpoint(receiver: &Socket) -> String {
+    receiver.get_last_endpoint().unwrap().unwrap()
+}
+#[cfg(target_os = "windows")]
+#[inline]
+fn get_endpoint(receiver: &Socket) -> String {
+    receiver.get_last_endpoint().unwrap().unwrap().replace("tcp://0.0.0.0", "tcp://127.0.0.1").to_owned()
+}
+
 fn create_socketpair() -> (Socket, Socket) {
     let ctx = Context::default();
 
@@ -18,7 +29,7 @@ fn create_socketpair() -> (Socket, Socket) {
     receiver.set_rcvtimeo(1000).unwrap();
 
     receiver.bind("tcp://*:*").unwrap();
-    let ep = receiver.get_last_endpoint().unwrap().unwrap();
+    let ep = get_endpoint(&receiver);
     sender.connect(&ep).unwrap();
 
     (sender, receiver)


### PR DESCRIPTION
On windows, connect() call fails when using the
return of get_last_endpoint() after a wild-card
bind, "tcp://0.0.0.0:<PORT>".
Instead, we must use the form
"tcp://127.0.0.1:<PORT>". This behavior is seen
in the libzmq library[1] itself.
 [1]: https://github.com/zeromq/libzmq/blob/905286261969d4e4b1b956f2befacb8c1eae5e35/tests/test_unbind_wildcard.cpp#L45-L49