### PR TITLE
bind "127.0.0.1:*" instead of "*:*"

### DIFF
--- a/tests/test.rs
+++ b/tests/test.rs
@@ -5,17 +5,6 @@ use std::net::TcpStream;
 use timebomb::timeout_ms;
 use zmq::*;
 
-#[cfg(not(target_os = "windows"))]
-#[inline]
-fn get_endpoint(receiver: &Socket) -> String {
-    receiver.get_last_endpoint().unwrap().unwrap()
-}
-#[cfg(target_os = "windows")]
-#[inline]
-fn get_endpoint(receiver: &Socket) -> String {
-    receiver.get_last_endpoint().unwrap().unwrap().replace("tcp://0.0.0.0", "tcp://127.0.0.1").to_owned()
-}
-
 fn create_socketpair() -> (Socket, Socket) {
     let ctx = Context::default();
 
@@ -28,8 +17,8 @@ fn create_socketpair() -> (Socket, Socket) {
     receiver.set_sndtimeo(1000).unwrap();
     receiver.set_rcvtimeo(1000).unwrap();
 
-    receiver.bind("tcp://*:*").unwrap();
-    let ep = get_endpoint(&receiver);
+    receiver.bind("tcp://127.0.0.1:*").unwrap();
+    let ep = receiver.get_last_endpoint().unwrap().unwrap();
     sender.connect(&ep).unwrap();
 
     (sender, receiver)


### PR DESCRIPTION
connecting() to an endpoint bound with wildcard
("*:*") is not necessarily defined behavior, and
does not work on windows. Use "127.0.0.1:*" instead
in tests.