### PR TITLE
Fix failing test_polling test on windows

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -90,6 +90,9 @@ zmq-sys = { version = "0.9.0", path = "zmq-sys" }
 compiletest_rs = { version = "0.*", optional = true }
 clippy = { version = "0.*", optional = true }
 
+[target.'cfg(target_os = "windows")'.dependencies]
+winapi = "0.2"
+
 [build-dependencies]
 zmq-sys = { version = "0.9.0", path = "zmq-sys" }
 


### PR DESCRIPTION
The PollItem field fd is defined as SOCKET
on Windows, which is a u64 on win64, as opposed to c_int.

Add dependency on winapi on windows, and define
the PollItem struct to use winapi::winsock2::SOCKET
when ``target_os = "windows"``.