### PR TITLE
Fixes for failing windows test, based on release/v0.8 branch

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1009,7 +1009,7 @@ pub static POLLERR: i16 = 4i16;
 #[repr(C)]
 pub struct PollItem<'a> {
     socket: *mut c_void,
-    fd: c_int,
+    fd: RawSocket,
     events: i16,
     revents: i16,
     marker: PhantomData<&'a Socket>
@@ -1018,7 +1018,7 @@ pub struct PollItem<'a> {
 impl<'a> PollItem<'a> {
     /// Construct a PollItem from a non-0MQ socket, given by its file
     /// descriptor.
-    pub fn from_fd(fd: c_int) -> PollItem<'a> {
+    pub fn from_fd(fd: RawSocket) -> PollItem<'a> {
         PollItem {
             socket: ptr::null_mut(),
             fd: fd,

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -17,7 +17,7 @@ fn create_socketpair() -> (Socket, Socket) {
     receiver.set_sndtimeo(1000).unwrap();
     receiver.set_rcvtimeo(1000).unwrap();
 
-    receiver.bind("tcp://*:*").unwrap();
+    receiver.bind("tcp://127.0.0.1:*").unwrap();
     let ep = receiver.get_last_endpoint().unwrap().unwrap();
     sender.connect(&ep).unwrap();
 


### PR DESCRIPTION
Fixes windows tests failing due to trying to ``connect()`` to and endpoint from a wildcard (``"*:*"``) bind.

Updates ``PollItem`` struct field ``fd`` to ``RawSocket`` type from ``zmq-sys`` crate, to fix ``test_polling``.