### PR TITLE
Extend shared-context test

### DIFF
--- a/tests/shared-context.rs
+++ b/tests/shared-context.rs
@@ -1,3 +1,9 @@
+//! These are all tests using PUSH/PULL sockets created from a shared
+//! context to connect two threads. As a compile-time test, this
+//! creates one socket from a context, and passes this context to the
+//! child thread, along with the endpoint address to connect to. The
+//! second socket is the created in the child thread.
+
 extern crate timebomb;
 extern crate zmq;
 
@@ -5,41 +11,69 @@ use std::thread;
 use std::str;
 use timebomb::timeout_ms;
 
+// TODO: factor out `test!` and use it here
+
 #[test]
 fn test_inproc() {
     timeout_ms(|| {
-        shared_context("inproc://pub");
+        run("inproc://pub", check_recv);
     }, 10000);
 }
 
 #[test]
 fn test_tcp() {
     timeout_ms(|| {
-        shared_context("tcp://127.0.0.1:*");
+        run("tcp://127.0.0.1:*", check_recv);
     }, 10000);
 }
 
-fn shared_context(address: &str) {
+#[test]
+fn test_poll_inproc() {
+    timeout_ms(|| {
+        run("inproc://pub", check_poll);
+    }, 10000);
+}
+
+#[test]
+fn test_poll_tcp() {
+    timeout_ms(|| {
+        run("tcp://127.0.0.1:*", check_poll);
+    }, 10000);
+}
+
+fn run<F>(address: &str, worker: F)
+    where F: Fn(zmq::Context, zmq::Socket) + Send + 'static
+{
     let ctx = zmq::Context::new();
 
     let push_socket = ctx.socket(zmq::PUSH).unwrap();
     push_socket.bind(address).unwrap();
     let endpoint = push_socket.get_last_endpoint().unwrap().unwrap();
-    let worker1 = fork(&ctx, endpoint);
+
+    let child = {
+        let w_ctx = ctx.clone();
+        thread::spawn(move || {
+            let pull_socket = connect_socket(&w_ctx, zmq::PULL, &endpoint).unwrap();
+            worker(w_ctx, pull_socket);
+        })
+    };
 
     push_socket.send(b"Message1", 0).unwrap();
 
-    worker1.join().unwrap();
+    child.join().unwrap();
 }
 
-fn fork(ctx: &zmq::Context, endpoint: String) -> thread::JoinHandle<()> {
-    let w_ctx = ctx.clone();
-    thread::spawn(move || { worker(&w_ctx, &endpoint); })
+fn check_poll(ctx: zmq::Context, pull_socket: zmq::Socket) {
+    {
+        let mut poll_items = vec![pull_socket.as_poll_item(zmq::POLLIN)];
+        assert_eq!(zmq::poll(&mut poll_items, 1000).unwrap(), 1);
+        assert_eq!(poll_items[0].get_revents(), zmq::POLLIN);
+    }
+
+    check_recv(ctx, pull_socket);
 }
 
-fn worker(ctx: &zmq::Context, endpoint: &str) {
-    let pull_socket = connect_socket(ctx, zmq::PULL, endpoint).unwrap();
-
+fn check_recv(_ctx: zmq::Context, pull_socket: zmq::Socket) {
     let msg = pull_socket.recv_msg(0).unwrap();
     assert_eq!(&msg[..], b"Message1");
 }


### PR DESCRIPTION
This now also smoke-tests polling, and is has been refactored a bit.