### PR TITLE
Allow converting `Error` into `std::io::Error`

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -347,6 +347,30 @@ impl fmt::Debug for Error {
     }
 }
 
+impl From<Error> for std::io::Error {
+    fn from(error: Error) -> Self {
+        use std::io::ErrorKind;
+
+        let kind = match error {
+            Error::ENOENT => ErrorKind::NotFound,
+            Error::EACCES => ErrorKind::PermissionDenied,
+            Error::ECONNREFUSED => ErrorKind::ConnectionRefused,
+            Error::ENOTCONN => ErrorKind::NotConnected,
+            Error::EADDRINUSE => ErrorKind::AddrInUse,
+            Error::EADDRNOTAVAIL => ErrorKind::AddrNotAvailable,
+            Error::EAGAIN => ErrorKind::WouldBlock,
+            Error::EINVAL => ErrorKind::InvalidInput,
+            Error::EINTR => ErrorKind::Interrupted,
+            _ => ErrorKind::Other
+        };
+        // TODO: With rust 1.14 and up there is an optimization
+        // opportunity using `std::io::Error: From<ErrorKind>` when
+        // `kind != Other`. We should do that once 1.14 has been
+        // stable for a bit.
+        std::io::Error::new(kind, error)
+    }
+}
+
 fn errno_to_error() -> Error {
     Error::from_raw(unsafe { zmq_sys::zmq_errno() })
 }

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -1,6 +1,7 @@
 extern crate timebomb;
 extern crate zmq;
 
+use std::io;
 use std::net::TcpStream;
 use timebomb::timeout_ms;
 use zmq::*;
@@ -139,6 +140,11 @@ test!(test_zmq_error, {
     let debug = format!("{:?}", err);
     assert_eq!(desc, display);
     assert_eq!(desc, debug);
+});
+
+test!(test_into_io_error, {
+    let e: io::Error = Error::ENOENT.into();
+    assert!(e.kind() == io::ErrorKind::NotFound);
 });
 
 #[cfg(ZMQ_HAS_CURVE = "1")]


### PR DESCRIPTION
This fixes #136.