### PR TITLE
Adjust poll event types

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,7 +11,7 @@ extern crate log;
 extern crate libc;
 extern crate zmq_sys;
 
-use libc::{c_int, c_long, size_t};
+use libc::{c_int, c_long, c_short, size_t};
 use std::ffi;
 use std::fmt;
 use std::marker::PhantomData;
@@ -1038,8 +1038,8 @@ pub static POLLERR: i16 = 4i16;
 pub struct PollItem<'a> {
     socket: *mut c_void,
     fd: RawFd,
-    events: i16,
-    revents: i16,
+    events: c_short,
+    revents: c_short,
     marker: PhantomData<&'a Socket>
 }
 


### PR DESCRIPTION
Change the type of `events` and `revents` from `i16` to `c_short`,
which it what is used in the C headers.