### PR TITLE
Introduce bitflags type for polling events

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -93,6 +93,7 @@ log = "0.3.6"
 zmq-sys = { version = "0.9.0", path = "zmq-sys" }
 compiletest_rs = { version = "0.*", optional = true }
 clippy = { version = "0.*", optional = true }
+bitflags = "0.7"
 
 [build-dependencies]
 zmq-sys = { version = "0.9.0", path = "zmq-sys" }

--- a/src/sockopt.rs
+++ b/src/sockopt.rs
@@ -5,7 +5,7 @@ use std::os::raw::c_void;
 use std::{mem, ptr, str};
 use std::result;
 
-use super::Result;
+use super::{Result, PollEvents};
 
 pub trait Getter where Self: Sized {
     fn get(sock: *mut c_void, opt: c_int) -> Result<Self>;
@@ -135,6 +135,12 @@ impl<'a> Setter for &'a [u8] {
             )
         });
         Ok(())
+    }
+}
+
+impl Getter for PollEvents {
+    fn get(sock: *mut c_void, opt: c_int) -> Result<Self> {
+        get::<c_int>(sock, opt).map(|bits| PollEvents::from_bits_truncate(bits as i16))
     }
 }
 

--- a/tests/compile-fail/no-leaking-poll-items.rs
+++ b/tests/compile-fail/no-leaking-poll-items.rs
@@ -4,6 +4,6 @@ fn main() {
     let context = zmq::Context::new();
     let _poll_item = {
         let socket = context.socket(zmq::PAIR).unwrap();
-        socket.as_poll_item(0)
+        socket.as_poll_item(zmq::POLLIN)
     }; //~ ERROR `socket` does not live long enough
 }

--- a/tests/connection/unix.rs
+++ b/tests/connection/unix.rs
@@ -42,14 +42,14 @@ impl<'a> PollState<'a> {
         let fd = socket.get_fd().unwrap();
         PollState {
             socket: socket,
-            available: 0,
+            available: zmq::PollEvents::empty(),
             fds: [poll::PollFd::new(fd, poll::POLLIN, poll::EventFlags::empty())],
         }
     }
 
     /// Wait for one of `events` to happen.
     fn wait(&mut self, events: zmq::PollEvents) {
-        while (self.available & events) == 0 {
+        while !self.available.intersects(events) {
             // FIXME: this has ugly scoping
             {
                 let fds = &mut self.fds;
@@ -71,7 +71,7 @@ impl<'a> PollState<'a> {
     /// This needs to be called after every sucessful receive or send
     /// on the socket.
     fn update(&mut self) {
-        self.available = self.socket.get_events().unwrap() as zmq::PollEvents;
+        self.available = self.socket.get_events().unwrap();
     }
 }
 


### PR DESCRIPTION
This improves type safety, and allows code to written in a more
readable style, at least for those not well-versed in C bitmaskery.

On the flip side, this is another incompatible API change.