### PR TITLE
Use metadeps to specify pkg-config dependencies declaratively

### DIFF
--- a/zmq-sys/Cargo.toml
+++ b/zmq-sys/Cargo.toml
@@ -16,4 +16,7 @@ links = "zmq"
 libc = "0.2.15"
 
 [build-dependencies]
-pkg-config = "0.3"
+metadeps = "1"
+
+[package.metadata.pkg-config]
+libzmq = "3.2"

--- a/zmq-sys/build.rs
+++ b/zmq-sys/build.rs
@@ -1,4 +1,4 @@
-extern crate pkg_config;
+extern crate metadeps;
 
 use std::env;
 
@@ -25,9 +25,8 @@ fn main() {
             panic!("Unable to locate libzmq library directory.")
         }
         (None, None) => {
-            match pkg_config::probe_library("libzmq") {
-                Ok(pkg) => println!("{:?}", pkg),
-                Err(e) => panic!("Unable to locate libzmq, err={:?}", e),
+            if let Err(e) = metadeps::probe() {
+                panic!("Unable to locate libzmq:\n{}", e);
             }
         }
     }


### PR DESCRIPTION
This makes it easier for distribution packaging tools to generate
appropriate package dependencies.