### PR TITLE
Add sockopt impl for u32 to support RawFd definition on stable-i686-pc-windows-msvc

### DIFF
--- a/src/sockopt.rs
+++ b/src/sockopt.rs
@@ -1,6 +1,6 @@
 extern crate zmq_sys;
 
-use libc::{c_int, size_t, int64_t, uint64_t};
+use libc::{c_int, c_uint, size_t, int64_t, uint64_t};
 use std::os::raw::c_void;
 use std::{mem, ptr, str};
 use std::result;
@@ -38,6 +38,7 @@ macro_rules! getsockopt_num(
 );
 
 getsockopt_num!(c_int, i32);
+getsockopt_num!(c_uint, u32);
 getsockopt_num!(int64_t, i64);
 getsockopt_num!(uint64_t, u64);
 


### PR DESCRIPTION
Compiling with 32bit rustc on windows leads to this error:

`the trait bound u32: sockopt::Getter is not satisfied`

because RawFd is defined as a u32 in this environment. I've added the impl to resolve this.

Also, the nightly build for this branch fails in Travis but it seems unrelated to this change but instead seems to be some text that changed in a rustc error message.