### PR TITLE
Alignment

### DIFF
--- a/src/sockopt.rs
+++ b/src/sockopt.rs
@@ -1,6 +1,6 @@
 extern crate zmq_sys;
 
-use libc::{c_int, size_t, int64_t, uint64_t};
+use libc::{c_int, c_uint, size_t, int64_t, uint64_t};
 use std::os::raw::c_void;
 use std::{mem, ptr, str};
 use std::result;
@@ -38,6 +38,7 @@ macro_rules! getsockopt_num(
 );
 
 getsockopt_num!(c_int, i32);
+getsockopt_num!(c_uint, u32);
 getsockopt_num!(int64_t, i64);
 getsockopt_num!(uint64_t, u64);
 

--- a/zmq-sys/src/ffi.rs
+++ b/zmq-sys/src/ffi.rs
@@ -3,7 +3,7 @@
 #[repr(C)]
 #[derive(Copy)]
 pub struct Struct_zmq_msg_t {
-    pub unnamed_field1: [::std::os::raw::c_uchar; 64usize],
+    pub unnamed_field1: [i64; 8usize],
 }
 impl ::std::clone::Clone for Struct_zmq_msg_t {
     fn clone(&self) -> Self { *self }


### PR DESCRIPTION
Running rust-zmq with a version of zeromq built with clang's address sanitizer and undefined behavior sanitizer yielded the following issue:

`SUMMARY: AddressSanitizer: undefined-behavior src\msg.cpp:64:7 in
src\msg.cpp:65:5: runtime error: member access within misaligned address 0x01596924 for type 'zmq::msg_t', which requires 8 byte alignment`

This struct being misaligned leads to reduced performance on x86 architectures and crashes on certain RISC architectures. The issue is due to the definition of Struct_zmq_msg_t in ffi.rs which defines the struct in terms of c_uchar which does not have 8 byte alignment requirements. Changing this struct to use an array of i64 (taken after the first member, int64_t file_desc, of zeromq's definition of zmq::msg_t) with 8 elements to maintain the size of this struct at 64 bytes resolves the alignment issue.