### PR TITLE
Add missing sockopt accessors

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -712,6 +712,8 @@ impl Socket {
         (is_plain_server, set_plain_server) => ZMQ_PLAIN_SERVER as bool,
         /// Accessor for the `ZMQ_CONFLATE` option.
         (is_conflate, set_conflate) => ZMQ_CONFLATE as bool,
+        (is_probe_router, set_probe_router) => ZMQ_PROBE_ROUTER as bool,
+        (is_router_mandatory, set_router_mandatory) => ZMQ_ROUTER_MANDATORY as bool,
         if ZMQ_HAS_CURVE {
             (is_curve_server, set_curve_server) => ZMQ_CURVE_SERVER as bool,
         },


### PR DESCRIPTION
* Add accessor for probe router
* Add accessor for router mandatory

![gif-keyboard-5368142348810602802](https://cloud.githubusercontent.com/assets/54036/22146644/3a4f9866-deba-11e6-834c-f057c3694806.gif)
