### PR TITLE
Make LIBZMQ_PREFIX construct valid Windows paths

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -1,0 +1,3 @@
+cd $(dirname $0)
+cargo build
+cargo test

--- a/rust-ubuntu.Dockerfile
+++ b/rust-ubuntu.Dockerfile
@@ -1,0 +1,46 @@
+## Credit to Andrew Scorpils
+## https://github.com/Scorpil/docker-rust/blob/master/1.5/Dockerfile
+##
+## We needed to build this on Ubuntu instead of Debian
+
+## This is changed ##
+FROM ubuntu:16.04
+#####################
+
+MAINTAINER Andrew Scorpil "dev@scorpil.com"
+
+ENV DEBIAN_FRONTEND=noninteractive
+
+RUN apt-get update && \
+    apt-get install \
+       ca-certificates \
+       curl \
+       gcc \
+       libc6-dev \
+       -qqy \
+       --no-install-recommends \
+    && rm -rf /var/lib/apt/lists/*
+
+ENV RUST_ARCHIVE=rust-1.14.0-x86_64-unknown-linux-gnu.tar.gz
+ENV RUST_DOWNLOAD_URL=https://static.rust-lang.org/dist/$RUST_ARCHIVE
+
+RUN curl -fOSL $RUST_DOWNLOAD_URL
+RUN curl $RUST_DOWNLOAD_URL.sha256 | sha256sum -c -
+
+RUN mkdir /rust
+RUN tar -C /rust -xzf $RUST_ARCHIVE --strip-components=1
+RUN rm $RUST_ARCHIVE
+WORKDIR /rust
+RUN ./install.sh
+
+WORKDIR /
+
+### Our custom stuff ###
+RUN apt-get update && \
+    apt-get install \
+       pkg-config \
+       libczmq-dev \
+       -qqy \
+    && rm -rf /var/lib/apt/lists/*
+RUN cargo install rustfmt
+ENV PATH="/root/.cargo/bin:${PATH}"

--- a/shippable.yml
+++ b/shippable.yml
@@ -1,0 +1,6 @@
+build:
+  pre_ci:
+    - docker build --tag=apa -f rust-ubuntu.Dockerfile .
+
+  ci:
+    - docker run -v $(pwd)/repo apa /repo/build.sh

--- a/zmq-sys/build.rs
+++ b/zmq-sys/build.rs
@@ -1,16 +1,19 @@
 extern crate metadeps;
 
 use std::env;
+use std::path::Path;
 
 fn main() {
     let lib_path = env::var("LIBZMQ_LIB_DIR").ok().or_else(|| {
         env::var("LIBZMQ_PREFIX").ok()
-            .map(|prefix| format!("{}/lib", prefix))
+            .map(|prefix| Path::new(&prefix).join("lib"))
+            .and_then(|path| path.to_str().map(|p| p.to_owned()))
     });
 
     let include = env::var("LIBZMQ_INCLUDE_DIR").ok().or_else(|| {
         env::var("LIBZMQ_PREFIX").ok()
-            .map(|prefix| format!("{}/include", prefix))
+            .map(|prefix| Path::new(&prefix).join("include"))
+            .and_then(|path| path.to_str().map(|p| p.to_owned()))
     });
 
     match (lib_path, include) {


### PR DESCRIPTION
Had some problems building on Windows,
```
Caused by:
  process didn't exit successfully: `rustc C:\Users\Troll\.cargo\registry\src\github.com-1ecc6299db9ec823\zmq-sys-0.8.1\src\lib.rs --crate-name zmq_sys --crate-type lib -g -C metadata=433048129add5453 -C extra-filename=-433048129add5453 --out-dir C:\Users\Troll\Downloads\talpid_core\target\debug\deps --emit=dep-info,link -L dependency=C:\Users\Troll\Downloads\talpid_core\target\debug\deps --extern libc=C:\Users\Troll\Downloads\talpid_core\target\debug\deps\liblibc-e1db4c5f3a4f3c2f.rlib --cap-lints allow -L native="c:\Program Files\ZeroMQ 4.0.4"/lib` (exit code: 101)
```
I noticed that `native="c:\Program Files\ZeroMQ 4.0.4"/lib` isn't a valid Windows path. This PR attempts to fix this, even though using `LIBZMQ_LIB_DIR` and `LIBZMQ_INCLUDE_DIR` works fine.

I'm really new to Rust and I had some real trouble converting my `PathBuf` to `String` so if that part of the code probably needs some fixing :)