### PR TITLE
Add curve smoke test

### DIFF
--- a/tests/curve.rs
+++ b/tests/curve.rs
@@ -1,0 +1,42 @@
+extern crate zmq;
+
+#[macro_use]
+mod common;
+
+use zmq::{Context, CurveKeyPair, Message, Socket};
+
+fn create_socketpair() -> (Socket, Socket) {
+    let ctx = Context::default();
+    let sender = ctx.socket(zmq::REQ).unwrap();
+    let receiver = ctx.socket(zmq::REP).unwrap();
+    let server_pair = CurveKeyPair::new().unwrap();
+    let client_pair = CurveKeyPair::new().unwrap();
+
+    // receiver socket acts as server, will accept connections
+    receiver.set_curve_server(true).unwrap();
+    receiver.set_curve_secretkey(&server_pair.secret_key).unwrap();
+
+    // sender socket, acts as client
+    sender.set_curve_serverkey(&server_pair.public_key).unwrap();
+    sender.set_curve_publickey(&client_pair.public_key).unwrap();
+    sender.set_curve_secretkey(&client_pair.secret_key).unwrap();
+
+    receiver.bind("tcp://127.0.0.1:*").unwrap();
+    let ep = receiver.get_last_endpoint().unwrap().unwrap();
+    sender.connect(&ep).unwrap();
+    (sender, receiver)
+}
+
+test!(test_curve_messages, {
+    let (sender, receiver) = create_socketpair();
+    sender.send_msg(Message::from_slice(b"foo").unwrap(), 0).unwrap();
+    let msg = receiver.recv_msg(0).unwrap();
+    assert_eq!(&msg[..], b"foo");
+    assert_eq!(msg.as_str(), Some("foo"));
+    println!("this is it {0}", msg.as_str().unwrap());
+    assert_eq!(format!("{:?}", msg), "[102, 111, 111]");
+    receiver.send(b"bar", 0).unwrap();
+    let mut msg = Message::with_capacity(1).unwrap();
+    sender.recv(&mut msg, 0).unwrap();
+    assert_eq!(&msg[..], b"bar");
+});

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -486,6 +486,7 @@ test!(test_getset_curve_serverkey, {
     assert_eq!(sock.get_curve_serverkey().unwrap().unwrap(), "FX5b8g5ZnOk7$Q}^)Y&?.v3&MIe+]OU7DTKynkUL");
 });
 
+
 test!(test_getset_conflate, {
     let ctx = Context::new();
     let sock = ctx.socket(REQ).unwrap();


### PR DESCRIPTION
This is a adapted version of the code posted in #164, taking
`tests/test_security_curve.cpp` from the libzmq test suite as a
template.