### PR TITLE
Add Socket::disconnect method

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -619,6 +619,13 @@ impl Socket {
         Ok(())
     }
 
+    /// Disconnect a previously connected socket
+    pub fn disconnect(&self, endpoint: &str) -> Result<()> {
+        let c_str = ffi::CString::new(endpoint.as_bytes()).unwrap();
+        zmq_try!(unsafe { zmq_sys::zmq_disconnect(self.sock, c_str.as_ptr()) });
+        Ok(())
+    }
+
     /// Send a `&[u8]` message.
     pub fn send(&self, data: &[u8], flags: i32) -> Result<()> {
         let msg = try!(Message::from_slice(data));

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -494,6 +494,22 @@ test!(test_getset_conflate, {
     assert_eq!(sock.is_conflate().unwrap(), true);
 });
 
+test!(test_disconnect, {
+    // Make a connected socket pair
+    let (sender, receiver) = create_socketpair();
+    // Now disconnect them
+    let ep = receiver.get_last_endpoint().unwrap().unwrap();
+    sender.disconnect(&ep).unwrap();
+    // And check that the message can no longer be sent
+    assert_eq!(Error::EAGAIN, sender.send_msg(Message::from_slice(b"foo").unwrap(), DONTWAIT).unwrap_err());
+});
+
+test!(test_disconnect_err, {
+    let (sender, _) = create_socketpair();
+    // Check that disconnect propagates errors. The endpoint is not connected.
+    assert_eq!(Error::ENOENT, sender.disconnect("tcp://192.0.2.1:2233").unwrap_err());
+});
+
 #[cfg(ZMQ_HAS_GSSAPI = "1")]
 test!(test_getset_gssapi_server, {
     let ctx = Context::new();


### PR DESCRIPTION
It is part of the C API and missing here.

The merge request is against the release/0.8 as adding a method should be API compatible change. Sorry I didn't open an issue for it upfront, I read the Contribution notes only after doing it, but I guess there's no other way the method could look like anyway and there's very little code written so it wouldn't matter if it would get thrown away.

As for motivation, I'd like to be able to shut down a worker gracefully, without losing messages in the input queue. If I disconnect first, I can process all messages in the queue and new ones won't arrive.