### PR TITLE
Fix errno::EPROTO build error on openbsd

### DIFF
--- a/zmq-sys/src/errno.rs
+++ b/zmq-sys/src/errno.rs
@@ -23,7 +23,7 @@ pub const ENOTSOCK:         i32 = errno::ENOTSOCK;
 #[cfg(not(target_os = "openbsd"))]
 pub const EPROTO:           i32 = errno::EPROTO;
 #[cfg(target_os = "openbsd")]
-pub const EPROTO:           i32 = errno::EIO;
+pub const EPROTO:           i32 = errno::EOPNOTSUPP;
 pub const EPROTONOSUPPORT:  i32 = errno::EPROTONOSUPPORT;
 
 #[cfg(not(target_os = "windows"))]

--- a/zmq-sys/src/errno.rs
+++ b/zmq-sys/src/errno.rs
@@ -20,7 +20,10 @@ pub const ENOENT:           i32 = errno::ENOENT;
 pub const ENOMEM:           i32 = errno::ENOMEM;
 pub const ENOTCONN:         i32 = errno::ENOTCONN;
 pub const ENOTSOCK:         i32 = errno::ENOTSOCK;
+#[cfg(not(target_os = "openbsd"))]
 pub const EPROTO:           i32 = errno::EPROTO;
+#[cfg(target_os = "openbsd")]
+pub const EPROTO:           i32 = errno::EIO;
 pub const EPROTONOSUPPORT:  i32 = errno::EPROTONOSUPPORT;
 
 #[cfg(not(target_os = "windows"))]


### PR DESCRIPTION
EPROTO is undefined on openbsd, so this works around the build failure.

I wrote a small program using rust-zmq and the library works nicely after this patch. Can you please cherrypick this commit and release it as 0.8.2? :)

Fixes #170