### PR TITLE
Fix EINTR errno -> Error

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -224,6 +224,7 @@ impl Error {
             errno::ENOBUFS            => Error::ENOBUFS,
             errno::ENETDOWN           => Error::ENETDOWN,
             errno::EADDRNOTAVAIL      => Error::EADDRNOTAVAIL,
+            errno::EINTR              => Error::EINTR,
             156384714                => Error::EPROTONOSUPPORT,
             156384715                => Error::ENOBUFS,
             156384716                => Error::ENETDOWN,

--- a/tests/error.rs
+++ b/tests/error.rs
@@ -1,0 +1,11 @@
+extern crate zmq;
+extern crate zmq_sys;
+
+use zmq::*;
+use zmq_sys::errno;
+
+#[test]
+fn from_raw_eintr() {
+  let error = Error::from_raw(errno::EINTR);
+  assert_eq!(error, Error::EINTR);
+}


### PR DESCRIPTION
Fixes #174. Drop for RawContext has a while EINTR loop handling
system interupts, however Error::from_raw cannot return this
Error. Adding it to the match allows this errno to be handled.