### PR TITLE
Add support for getting libraries from vcpkg for MSVC ABI builds

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,10 +37,24 @@ Install for developers:
     % cargo build
 
 The build normally uses `pkg-config` to find out about libzmq's
-location. If that is not available, the environment variable
+location.
+
+MSVC ABI builds will find libraries in a
+[Vcpkg](https://github.com/Microsoft/vcpkg) ports tree
+if there is one available either via the `vcpkg integrate install`
+mechanism or the `VCPKG_ROOT` environment variable. For example to
+install the static library for x86-64-pc-windows-msvc use the
+following command:
+
+    vcpkg install zeromq:x64-windows-static
+
+See the [Vcpkg cargo helper](https://docs.rs/vcpkg)
+documentation for more information.
+
+The environment variable
 `LIBZMQ_PREFIX` (or alternatively, `LIBZMQ_LIB_DIR` and
-`LIBZMQ_INCLUDE_DIR`) can be defined to avoid the invocation of
-`pkg-config`.
+`LIBZMQ_INCLUDE_DIR`) can be defined to avoid use of
+`pkg-config` or `vcpkg`.
 
 Usage
 -----

--- a/tests/curve.rs
+++ b/tests/curve.rs
@@ -1,3 +1,4 @@
+#![cfg(ZMQ_HAS_CURVE = "1")]
 extern crate zmq;
 
 #[macro_use]

--- a/zmq-sys/Cargo.toml
+++ b/zmq-sys/Cargo.toml
@@ -17,6 +17,7 @@ libc = "0.2.15"
 
 [build-dependencies]
 metadeps = "1"
+vcpkg = "0.1.7"
 
 [package.metadata.pkg-config]
 libzmq = "3.2"


### PR DESCRIPTION
With vcpkg installed, 

```
vcpkg install zeromq:x64-windows-static
cargo build
```

now works.

I removed  `#[link(name = "zmq")]` from `ffi.rs`. This did not break the default style build for linux or mac - is it related to static linking, and if so how would I go about testing that? I did not emit a `cargo:rustc-link-lib=zmq` but I will do so if it is required.

I tested static and dynamic builds with x86_64-pc-windows-msvc. The zmq crate itself as of 0.8.1 does not appear to compile for i686-pc-windows-msvc. 