### PR TITLE
add a few zguide examples, remove mutable references in proxy

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -103,6 +103,10 @@ path = "examples/zguide/rrbroker/main.rs"
 name = "msgqueue"
 path = "examples/zguide/msgqueue/main.rs"
 
+[[example]]
+name = "wuproxy"
+path = "examples/zguide/wuproxy/main.rs"
+
 [dependencies]
 libc = "0.2.15"
 log = "0.3.6"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -87,6 +87,18 @@ path = "examples/zguide/rtdealer/main.rs"
 name = "fileio3"
 path = "examples/zguide/fileio3/main.rs"
 
+[[example]]
+name = "rrclient"
+path = "examples/zguide/rrclient/main.rs"
+
+[[example]]
+name = "rrworker"
+path = "examples/zguide/rrworker/main.rs"
+
+[[example]]
+name = "rrbroker"
+path = "examples/zguide/rrbroker/main.rs"
+
 [dependencies]
 libc = "0.2.15"
 log = "0.3.6"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -99,6 +99,10 @@ path = "examples/zguide/rrworker/main.rs"
 name = "rrbroker"
 path = "examples/zguide/rrbroker/main.rs"
 
+[[example]]
+name = "msgqueue"
+path = "examples/zguide/msgqueue/main.rs"
+
 [dependencies]
 libc = "0.2.15"
 log = "0.3.6"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -107,6 +107,14 @@ path = "examples/zguide/msgqueue/main.rs"
 name = "wuproxy"
 path = "examples/zguide/wuproxy/main.rs"
 
+[[example]]
+name = "tasksink2"
+path = "examples/zguide/tasksink2/main.rs"
+
+[[example]]
+name = "taskwork2"
+path = "examples/zguide/taskwork2/main.rs"
+
 [dependencies]
 libc = "0.2.15"
 log = "0.3.6"

--- a/examples/zguide/msgqueue/main.rs
+++ b/examples/zguide/msgqueue/main.rs
@@ -1,0 +1,15 @@
+#![crate_name = "msgqueue"]
+
+extern crate zmq;
+
+fn main(){
+    let context = zmq::Context::new();
+    let frontend = context.socket(zmq::ROUTER).unwrap();
+    let backend = context.socket(zmq::DEALER).unwrap();
+
+    frontend.bind("tcp://*:5559").expect("failed binding frontend");
+    backend.bind("tcp://*:5560").expect("failed binding backend");
+
+    zmq::proxy(&frontend, &backend).expect("failed to proxy");
+
+}

--- a/examples/zguide/rrbroker/main.rs
+++ b/examples/zguide/rrbroker/main.rs
@@ -1,0 +1,42 @@
+#![crate_name = "rrbroker"]
+
+extern crate zmq;
+
+fn main(){
+    let context = zmq::Context::new();
+    let frontend = context.socket(zmq::ROUTER).unwrap();
+    let backend = context.socket(zmq::DEALER).unwrap();
+    
+    frontend.bind("tcp://*:5559").expect("failed binding frontend");
+    backend.bind("tcp://*:5560").expect("failed binding backend");
+    
+    loop {
+        let mut items = [
+                frontend.as_poll_item(zmq::POLLIN),
+                backend.as_poll_item(zmq::POLLIN),
+                ];
+        zmq::poll(&mut items, -1).unwrap();
+        
+        if items[0].is_readable() {
+            loop{
+                let message = frontend.recv_msg(0).unwrap();
+                let more = message.get_more();
+                backend.send(message, if more {zmq::SNDMORE} else {0}).unwrap();
+                if !more {
+                    break;
+                }
+            }
+        }    
+        if items[1].is_readable() {
+            loop{
+                let message = backend.recv_msg(0).unwrap();
+                let more = message.get_more();
+                frontend.send(message, if more {zmq::SNDMORE} else {0}).unwrap();
+                if !more {
+                    break;
+                }
+        
+            }
+        }     
+    }
+}

--- a/examples/zguide/rrclient/main.rs
+++ b/examples/zguide/rrclient/main.rs
@@ -1,0 +1,15 @@
+#![crate_name = "rrclient"]
+
+extern crate zmq;
+
+fn main(){
+    let context = zmq::Context::new();
+    let requester = context.socket(zmq::REQ).unwrap();
+    requester.connect("tcp://localhost:5559").expect("failed to connect requester");
+    for request_nbr in 0..10{
+        requester.send("Hello",0).unwrap();
+        let message = requester.recv_msg(0).unwrap();
+        println! ("Received reply {} {}", request_nbr, message.as_str().unwrap());
+
+    }
+}

--- a/examples/zguide/rrworker/main.rs
+++ b/examples/zguide/rrworker/main.rs
@@ -1,0 +1,20 @@
+#![crate_name = "rrworker"]
+
+extern crate zmq;
+use std::thread;
+use std::time::Duration;
+
+fn main(){
+    let context = zmq::Context::new();
+    let responder = context.socket(zmq::REP).unwrap();
+    responder.connect("tcp://localhost:5560").expect("failed connecting responder");
+
+    loop{
+        let string = responder.recv_string(0).unwrap().unwrap();
+        println! ("Received request:{}", string);
+        thread::sleep(Duration::from_millis(1000));
+        responder.send("World",0).unwrap();
+
+
+    }
+}

--- a/examples/zguide/tasksink2/main.rs
+++ b/examples/zguide/tasksink2/main.rs
@@ -1,0 +1,41 @@
+#![crate_name = "tasksink2"]
+
+/// Task sink
+/// Binds PULL socket to tcp://localhost:5558
+/// Collects results from workers via that socket
+
+extern crate zmq;
+
+use std::io::{self, Write};
+use std::time::Instant;
+
+fn main() {
+    //  Prepare our context and socket
+    let context = zmq::Context::new();
+    let receiver = context.socket(zmq::PULL).unwrap();
+    assert!(receiver.bind("tcp://*:5558").is_ok());
+    
+    let controller = context.socket(zmq::PUB).unwrap();
+    controller.bind("tcp://*:5559").expect("failed to bind controller");
+
+    // Wait for start of batch
+    receiver.recv_bytes(0).unwrap();
+
+    //  Start our clock now
+    let start = Instant::now();
+
+    for task_nbr in 0..100 {
+        receiver.recv_bytes(0).unwrap();
+
+        if task_nbr % 10 == 0 {
+            print!(":");
+        } else {
+            print!(".");
+        }
+        let _ = io::stdout().flush();
+    }
+
+    println!("\nTotal elapsed time: {:?}", start.elapsed());
+    //send kill signal
+    controller.send("KILL",0).expect("failed to send kill signal");
+}

--- a/examples/zguide/taskwork2/main.rs
+++ b/examples/zguide/taskwork2/main.rs
@@ -1,0 +1,62 @@
+#![crate_name = "taskwork2"]
+
+/// Task worker
+/// Connects PULL socket to tcp://localhost:5557
+/// Collects workloads from ventilator via that socket
+/// Connects PUSH socket to tcp://localhost:5558
+/// Sends results to sink via that socket
+
+extern crate zmq;
+
+use std::io::{self, Write};
+use std::thread;
+use std::time::Duration;
+
+fn atoi(s: &str) -> u64 {
+    s.parse().unwrap()
+}
+
+fn main() {
+    let context = zmq::Context::new();
+
+    // socket to receive messages on
+    let receiver = context.socket(zmq::PULL).unwrap();
+    assert!(receiver.connect("tcp://localhost:5557").is_ok());
+
+    //  Socket to send messages to
+    let sender = context.socket(zmq::PUSH).unwrap();
+    assert!(sender.connect("tcp://localhost:5558").is_ok());
+    
+    let controller = context.socket(zmq::SUB).unwrap();
+    controller.connect("tcp://localhost:5559").expect("failed connecting controller");
+    controller.set_subscribe("".as_bytes()).expect("failed subscribing");
+
+
+    loop {
+        let mut items = [
+            receiver.as_poll_item(zmq::POLLIN),
+            controller.as_poll_item(zmq::POLLIN)
+        ];
+        zmq::poll(&mut items, -1).expect("failed polling");
+        if items[0].is_readable(){
+            
+        
+
+            let string = receiver.recv_string(0).unwrap().unwrap();
+
+        // Show progress
+            print!(".");
+            let _ = io::stdout().flush();
+
+        // Do the work
+            thread::sleep(Duration::from_millis(atoi(&string)));
+
+            // Send results to sink
+            sender.send("", 0).unwrap();
+        }
+        if items[1].is_readable(){
+            break;
+        }
+     }
+
+}

--- a/examples/zguide/wuproxy/main.rs
+++ b/examples/zguide/wuproxy/main.rs
@@ -1,0 +1,14 @@
+#![crate_name = "wuproxy"]
+
+extern crate zmq;
+
+fn main(){
+    let context = zmq::Context::new();
+    let frontend = context.socket(zmq::XSUB).unwrap();
+    let backend = context.socket(zmq::XPUB).unwrap();
+
+    frontend.connect("tcp://192.168.55.210:5556").expect("failed connecting frontend");
+    backend.bind("tcp://10.1.1.0:8100").expect("failed binding backend");
+    zmq::proxy(&frontend, &backend).expect("failed proxying");
+
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1019,8 +1019,8 @@ pub fn poll(items: &mut [PollItem], timeout: i64) -> Result<i32> {
 ///
 /// This function only returns (always with an `Err`) when the sockets' context
 /// has been closed.
-pub fn proxy(frontend: &mut Socket,
-             backend: &mut Socket) -> Result<()> {
+pub fn proxy(frontend: &Socket,
+             backend: &Socket) -> Result<()> {
     zmq_try!(unsafe { zmq_sys::zmq_proxy(frontend.sock, backend.sock, ptr::null_mut()) });
     Ok(())
 }


### PR DESCRIPTION
generally followed the existing examples. However, for the socket methods I use expect rather than asserting is_ok so you get a message if the call fails. Seemed a bit cleaner and gives a clearer error message.

Change to proxy is as per https://github.com/erickt/rust-zmq/commit/b307f7cb076469f5432f772048650a058f43284f