### PR TITLE
Add `PollItem::set_events`

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -995,6 +995,11 @@ impl<'a> PollItem<'a> {
         }
     }
 
+    /// Change the events to wait for.
+    pub fn set_events(&mut self, events: PollEvents) {
+        self.events = events;
+    }
+
     /// Retrieve the events that occurred for this handle.
     pub fn get_revents(&self) -> PollEvents {
         self.revents

--- a/tests/poll.rs
+++ b/tests/poll.rs
@@ -1,0 +1,3 @@
+#[cfg(unix)]
+#[path = "poll/unix.rs"]
+mod unix;

--- a/tests/poll/unix.rs
+++ b/tests/poll/unix.rs
@@ -1,0 +1,31 @@
+// Test whether `zmq::poll()` works with `PollItem`s constructed from
+// arbitrary FDs.
+
+extern crate nix;
+extern crate zmq;
+
+use std::thread;
+use std::os::unix::io::RawFd;
+use self::nix::unistd;
+
+#[test]
+fn test_pipe_poll() {
+    let (pipe_read, pipe_write) = unistd::pipe().expect("pipe creation failed");
+    let writer_thread = thread::spawn(move || { pipe_writer(pipe_write); });
+    let mut pipe_item = zmq::PollItem::from_fd(pipe_read);
+    pipe_item.set_events(zmq::POLLIN);
+
+    let mut poll_items = [pipe_item];
+    assert_eq!(zmq::poll(&mut poll_items, 1000).unwrap(), 1);
+    assert_eq!(poll_items[0].get_revents(), zmq::POLLIN);
+
+    let mut buf = vec![0];
+    assert_eq!(unistd::read(pipe_read, &mut buf).unwrap(), 1);
+    assert_eq!(buf, b"X");
+
+    writer_thread.join().unwrap();
+}
+
+fn pipe_writer(fd: RawFd) {
+    unistd::write(fd, b"X").expect("pipe write failed");
+}


### PR DESCRIPTION
This rectifies missing API coverage: there was previously no way to
construct a `PollItem` from an arbitrary file descriptor with a
non-zero event field.

Fixes #193.