### PR TITLE
Let `PollItem::from_fd` take the events to poll for

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -959,12 +959,12 @@ pub struct PollItem<'a> {
 
 impl<'a> PollItem<'a> {
     /// Construct a PollItem from a non-0MQ socket, given by its file
-    /// descriptor.
-    pub fn from_fd(fd: RawFd) -> PollItem<'a> {
+    /// descriptor and the events that should be polled.
+    pub fn from_fd(fd: RawFd, events: PollEvents) -> PollItem<'a> {
         PollItem {
             socket: ptr::null_mut(),
             fd: fd,
-            events: 0,
+            events: events.bits(),
             revents: 0,
             marker: PhantomData
         }

--- a/tests/poll/unix.rs
+++ b/tests/poll/unix.rs
@@ -12,8 +12,7 @@ use self::nix::unistd;
 fn test_pipe_poll() {
     let (pipe_read, pipe_write) = unistd::pipe().expect("pipe creation failed");
     let writer_thread = thread::spawn(move || { pipe_writer(pipe_write); });
-    let mut pipe_item = zmq::PollItem::from_fd(pipe_read);
-    pipe_item.set_events(zmq::POLLIN);
+    let pipe_item = zmq::PollItem::from_fd(pipe_read, zmq::POLLIN);
 
     let mut poll_items = [pipe_item];
     assert_eq!(zmq::poll(&mut poll_items, 1000).unwrap(), 1);


### PR DESCRIPTION
As the set of events to poll for needs to be set in every case, let
the caller specify it up front, instead of having to invoke
`PollItem::set_events` after creating the poll item.