### PR TITLE
zmq-sys: Remove redundant `link` attribute

### DIFF
--- a/zmq-sys/src/ffi.rs
+++ b/zmq-sys/src/ffi.rs
@@ -33,7 +33,7 @@ pub type zmq_pollitem_t = Struct_zmq_pollitem_t;
 pub enum Struct_iovec { }
 pub type zmq_thread_fn =
     unsafe extern "C" fn(arg1: *mut ::std::os::raw::c_void);
-#[link(name = "zmq")]
+
 extern "C" {
     pub fn zmq_errno() -> ::std::os::raw::c_int;
     pub fn zmq_strerror(errnum: ::std::os::raw::c_int)


### PR DESCRIPTION
As we use pkg-config by way of the `metadeps` crate, we do not need to
specify the library name in the source.

This gets rid of the "redundant linker flag" warning when building
`zmq-sys`; fixes #196.

See also: <https://github.com/Rust-SDL2/rust-sdl2/issues/615>