### PR TITLE
Add support for ZMQ Monitor Sockets

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,10 @@ name = "helloworld_server"
 path = "examples/zguide/helloworld_server/main.rs"
 
 [[example]]
+name = "monitor"
+path = "examples/zguide/monitor/main.rs"
+
+[[example]]
 name = "msreader"
 path = "examples/zguide/msreader/main.rs"
 

--- a/examples/zguide/monitor/main.rs
+++ b/examples/zguide/monitor/main.rs
@@ -1,0 +1,128 @@
+#![crate_name = "monitor"]
+
+
+
+extern crate zmq;
+use std::str;
+
+/// Read one event off the monitor socket; return the SocketEvent value.
+fn get_monitor_event(monitor: &mut zmq::Socket)
+    -> zmq::Result<zmq::SocketEvent>
+{
+    let mut msg = zmq::Message::new()?;
+    monitor.recv(&mut msg, 0)?;
+    let event= ((msg[1] as u16) << 8) | msg[0] as u16;
+
+    assert!(monitor.get_rcvmore()?,
+            "Monitor socket should have two messages per event");
+
+    // the address, we'll ignore it
+    monitor.recv(&mut msg, 0)?;
+
+    Ok(zmq::SocketEvent::from_raw(event))
+}
+
+/// Send a series of pings between the client and the server.
+/// The messages should round trip from the client to the server
+/// and back again.
+fn bounce(client: &mut zmq::Socket, server: &mut zmq::Socket) {
+    let data = "12345678ABCDEFGH12345678abcdefgh";
+
+    //  Send message from client to server
+    client.send(data.as_bytes(), zmq::SNDMORE).unwrap();
+    client.send(data.as_bytes(), 0).unwrap();
+
+    //  Receive message at server side
+    let mut recv_data = server.recv_bytes(0).unwrap();
+    assert_eq!(str::from_utf8(&recv_data).unwrap(), data);
+    assert!(server.get_rcvmore().unwrap());
+
+    recv_data = server.recv_bytes(0).unwrap();
+    assert_eq!(str::from_utf8(&recv_data).unwrap(), data);
+    assert!(!server.get_rcvmore().unwrap());
+
+    //  Send message from client to server
+    server.send(&recv_data, zmq::SNDMORE).unwrap();
+    server.send(&recv_data, 0).unwrap();
+
+    //  Receive the two parts at the client side
+    recv_data = client.recv_bytes(0).unwrap();
+    assert_eq!(str::from_utf8(&recv_data).unwrap(), data);
+    assert!(client.get_rcvmore().unwrap());
+
+    recv_data = client.recv_bytes(0).unwrap();
+    assert_eq!(str::from_utf8(&recv_data).unwrap(), data);
+    assert!(!client.get_rcvmore().unwrap());
+}
+
+/// Close the given socket with LINGER set to 0
+fn close_zero_linger(socket: &mut zmq::Socket) {
+    socket.set_linger(0).unwrap();
+    drop(socket);
+}
+
+fn main() {
+    let ctx = zmq::Context::new();
+
+    let mut client = ctx.socket(zmq::DEALER).unwrap();
+    let mut server = ctx.socket(zmq::DEALER).unwrap();
+
+    let err = client.monitor("tcp://127.0.0.1:9999", 0).expect_err(
+        "Socket monitoring only works over inproc://");
+    assert_eq!(zmq::Error::EPROTONOSUPPORT, err);
+
+    assert!(client.monitor("inproc://monitor-client",
+                           zmq::SocketEvent::ALL as i32).is_ok());
+    assert!(server.monitor("inproc://monitor-server",
+                           zmq::SocketEvent::ALL as i32).is_ok());
+
+    let mut client_mon = ctx.socket(zmq::PAIR).unwrap();
+    let mut server_mon = ctx.socket(zmq::PAIR).unwrap();
+
+    // Connect these to the inproc endpoints so they'll get events
+    client_mon.connect("inproc://monitor-client").unwrap();
+    server_mon.connect("inproc://monitor-server").unwrap();
+
+    // Now do a basic ping test
+    server.bind("tcp://127.0.0.1:9998").unwrap();
+    client.connect("tcp://127.0.0.1:9998").unwrap();
+    bounce(&mut client, &mut server);
+
+    // Close client and server
+    close_zero_linger(&mut client);
+    close_zero_linger(&mut server);
+
+    // Now collect and check events from both sockets
+    let mut event = get_monitor_event(&mut client_mon).unwrap();
+    println!("got client monitor event {:?}", event);
+    if event == zmq::SocketEvent::CONNECT_DELAYED {
+        event = get_monitor_event(&mut client_mon).unwrap();
+        println!("got client monitor event {:?}", event);
+    }
+    assert_eq!(zmq::SocketEvent::CONNECTED, event);
+
+    event = get_monitor_event(&mut client_mon).unwrap();
+    assert_eq!(zmq::SocketEvent::MONITOR_STOPPED, event);
+    println!("got client monitor event {:?}", event);
+
+    // This is the flow of server events
+    event = get_monitor_event(&mut server).unwrap();
+    println!("got server monitor event {:?}", event);
+    assert_eq!(zmq::SocketEvent::LISTENING, event);
+
+    event = get_monitor_event(&mut server).unwrap();
+    println!("got server monitor event {:?}", event);
+    assert_eq!(zmq::SocketEvent::ACCEPTED, event);
+
+    event = get_monitor_event(&mut server).unwrap();
+    println!("got server monitor event {:?}", event);
+    assert_eq!(zmq::SocketEvent::CLOSED, event);
+
+    event = get_monitor_event(&mut server).unwrap();
+    println!("got server monitor event {:?}", event);
+    assert_eq!(zmq::SocketEvent::MONITOR_STOPPED, event);
+
+    // Close down the sockets
+    close_zero_linger(&mut client_mon);
+    close_zero_linger(&mut server_mon);
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -63,6 +63,50 @@ pub enum SocketType {
 
 impl Copy for SocketType {}
 
+/// Socket Events
+#[allow(non_camel_case_types)]
+#[derive(Clone, Debug, PartialEq)]
+pub enum SocketEvent {
+    CONNECTED       = 0x0001,
+    CONNECT_DELAYED = 0x0002,
+    CONNECT_RETRIED = 0x0004,
+    LISTENING       = 0x0008,
+    BIND_FAILED     = 0x0010,
+    ACCEPTED        = 0x0020,
+    ACCEPT_FAILED   = 0x0040,
+    CLOSED          = 0x0080,
+    CLOSE_FAILED    = 0x0100,
+    DISCONNECTED    = 0x0200,
+    MONITOR_STOPPED = 0x0400,
+    ALL             = 0xFFFF,
+}
+
+impl Copy for SocketEvent {}
+
+impl SocketEvent {
+    pub fn to_raw(&self) -> u16 {
+        *self as u16
+    }
+
+    pub fn from_raw(raw: u16) -> SocketEvent {
+        match raw {
+            0x0001 => SocketEvent::CONNECTED,
+            0x0002 => SocketEvent::CONNECT_DELAYED,
+            0x0004 => SocketEvent::CONNECT_RETRIED,
+            0x0008 => SocketEvent::LISTENING,
+            0x0010 => SocketEvent::BIND_FAILED,
+            0x0020 => SocketEvent::ACCEPTED,
+            0x0040 => SocketEvent::ACCEPT_FAILED,
+            0x0080 => SocketEvent::CLOSED,
+            0x0100 => SocketEvent::CLOSE_FAILED,
+            0x0200 => SocketEvent::DISCONNECTED,
+            0x0400 => SocketEvent::MONITOR_STOPPED,
+            0xFFFF => SocketEvent::ALL,
+            x => panic!("unknown event type {}", x),
+        }
+    }
+}
+
 /// Flag for socket `send` methods that specifies non-blocking mode.
 pub static DONTWAIT: i32 = 1;
 /// Flag for socket `send` methods that specifies that more frames of a
@@ -626,6 +670,13 @@ impl Socket {
     pub fn disconnect(&self, endpoint: &str) -> Result<()> {
         let c_str = ffi::CString::new(endpoint.as_bytes()).unwrap();
         zmq_try!(unsafe { zmq_sys::zmq_disconnect(self.sock, c_str.as_ptr()) });
+        Ok(())
+    }
+
+    /// Configure the socket for monitoring
+    pub fn monitor(&self, monitor_endpoint: &str, events: i32) -> Result<()> {
+        let c_str = ffi::CString::new(monitor_endpoint.as_bytes()).unwrap();
+        zmq_try!(unsafe { zmq_sys::zmq_socket_monitor(self.sock, c_str.as_ptr(), events as c_int) });
         Ok(())
     }
 


### PR DESCRIPTION
Add support for configuring a socket for tracking socket events.  This includes creating a wrapper function on Socket for the `zmq_socket_monitor` call, a `SocketEvents` enum and a monitor example.

Note, the example, which is based on the [libzmq C example](http://api.zeromq.org/4-1:zmq-socket-monitor), hangs after receives two of the events on client monitor socket. Any feed back for that error would be appreciated.
