### PR TITLE
Replaced #[path] with some #[cfg] attributes to avoid an ICE

### DIFF
--- a/zmq-sys/src/errno.rs
+++ b/zmq-sys/src/errno.rs
@@ -1,4 +1,7 @@
-use imp::errno as errno;
+#[cfg(unix)]
+use libc as errno;
+#[cfg(windows)]
+use windows::errno;
 
 const ZMQ_HAUSNUMERO: i32 = 156384712;
 

--- a/zmq-sys/src/lib.rs
+++ b/zmq-sys/src/lib.rs
@@ -1,20 +1,17 @@
-
 extern crate libc;
 
-#[path = "unix.rs"]
 #[cfg(unix)]
-mod imp;
+mod unix;
+#[cfg(unix)]
+pub use unix::RawFd;
 
-#[path = "windows.rs"]
 #[cfg(windows)]
-mod imp;
+mod windows;
+#[cfg(windows)]
+pub use windows::RawFd;
 
 pub mod errno;
 
-pub use imp::{
-    // This maps to `RawFd` on Unixoids and `RawSocket` on Windows.
-    RawFd,
-};
 
 pub use ffi::{
     zmq_msg_t,

--- a/zmq-sys/src/unix.rs
+++ b/zmq-sys/src/unix.rs
@@ -1,4 +1,1 @@
-pub extern crate libc;
-
 pub use std::os::unix::io::RawFd;
-pub use self::libc as errno;


### PR DESCRIPTION
In `zmq-sys`, the use of the `#[path]` attribute to make things more cross-platform causes an ICE when running `cargo doc` on nightly.

cc: rust-lang/rust#47391