### PR TITLE
Activate `zmq::has`

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -3,6 +3,7 @@ extern crate zmq_sys as zmq;
 #[cfg(feature = "zmq_has")]
 fn main() {
     use std::ffi::CString;
+    println!("cargo:rustc-cfg=ZMQ_HAS_ZMQ_HAS");
 
     for has in ["ipc", "pgm", "tipc", "norm", "curve", "gssapi"].into_iter() {
         if unsafe { zmq::zmq_has(CString::new(has.as_bytes()).unwrap().as_ptr()) } == 1 {
@@ -53,7 +54,7 @@ fn main() {
         let mut _patch = 0;
         zmq::zmq_version(&mut major, &mut minor, &mut _patch);
         if major >= 4 && minor >= 1 {
-            println!("cargo:rust-cfg=ZMQ_HAS_ZMQ_HAS=\"1\"");
+            println!("cargo:rustc-cfg=ZMQ_HAS_ZMQ_HAS");
         }
     }
 }

--- a/tests/has.rs
+++ b/tests/has.rs
@@ -1,0 +1,9 @@
+extern crate zmq;
+
+#[test]
+fn test_has() {
+    if cfg!(ZMQ_HAS_ZMQ_HAS) {
+        // It doesn't matter whether the feature is supported or not, it must return Some(_)
+        assert!(zmq::has("ipc").is_some());
+    }
+}


### PR DESCRIPTION
As released, `zmq::has` will always return `None` because the compiler flag `ZMQ_HAS_ZMQ_HAS` wasn't set at all when feature `has_zmq` was enabled, and was incorrectly set (`="1"`) when it was wrapped.

This PR makes the necessary adjustments to the build script, and adds a test to check that `zmq::has` is actually being called (i.e. it returns `Some(_)`)  