### PR TITLE
Fix `zmq::has` feature detection

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -3,12 +3,13 @@ extern crate zmq_sys as zmq;
 #[cfg(feature = "zmq_has")]
 fn main() {
     use std::ffi::CString;
+    println!("cargo:rustc-cfg=ZMQ_HAS_ZMQ_HAS");
 
-	for has in ["ipc", "pgm", "tipc", "norm", "curve", "gssapi"].into_iter() {
-		if unsafe { zmq::zmq_has(CString::new(has.as_bytes()).unwrap().as_ptr()) } == 1 {
-			println!("cargo:rustc-cfg=ZMQ_HAS_{}=\"1\"", has.to_uppercase());
-		}
-	}
+    for has in ["ipc", "pgm", "tipc", "norm", "curve", "gssapi"].into_iter() {
+        if unsafe { zmq::zmq_has(CString::new(has.as_bytes()).unwrap().as_ptr()) } == 1 {
+            println!("cargo:rustc-cfg=ZMQ_HAS_{}=\"1\"", has.to_uppercase());
+        }
+    }
 }
 
 #[cfg(not(feature = "zmq_has"))]
@@ -50,7 +51,7 @@ fn main() {
         let mut _patch = 0;
         zmq::zmq_version(&mut major, &mut minor, &mut _patch);
         if major >= 4 && minor >= 1 {
-            println!("cargo:rust-cfg=ZMQ_HAS_ZMQ_HAS=\"1\"");
+            println!("cargo:rustc-cfg=ZMQ_HAS_ZMQ_HAS");
         }
     }
 }

--- a/tests/has.rs
+++ b/tests/has.rs
@@ -1,0 +1,11 @@
+extern crate zmq;
+
+#[test]
+fn test_has() {
+    if cfg!(ZMQ_HAS_ZMQ_HAS) {
+        // It doesn't matter whether the feature is supported or not, it must return Some(_)
+        assert!(zmq::has("ipc").is_some());
+    } else {
+        assert!(zmq::has("ipc").is_none());
+    }
+}


### PR DESCRIPTION
Before this commit, `zmq::has` will always return `None` because the
compiler flag ZMQ_HAS_ZMQ_HAS wasn't set at all when feature `zmq_has`
was enabled, and was incorrectly set (typo "rust-cfg" instead of
"rustc-cfg") when the `zmq_has` feature was not enabled, but a
new-enough version of libzmq was detected.

This commit makes the necessary adjustments to the build script, and
adds a test to check that zmq::has is actually being called (i.e. it
returns Some(_)).