### PR TITLE
Introduce `static-libzmq` crate feature for easier building of zmq crate.

### DIFF
--- a/.appveyor/appveyor.bat
+++ b/.appveyor/appveyor.bat
@@ -115,3 +115,6 @@ if %ERRORLEVEL% NEQ 0 exit 1
 
 cargo test -vv %CARGO_MODE%
 if %ERRORLEVEL% NEQ 0 exit 1
+
+cargo test -vv --features static-libzmq %CARGO_MODE%
+if %ERRORLEVEL% NEQ 0 exit 1

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "zmq-sys/libzmq"]
+	path = zmq-sys/libzmq
+	url = https://github.com/zeromq/libzmq

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -81,6 +81,7 @@ unstable = []
 default = ["zmq_has"]
 zmq_has = [] # zmq_has was added in zeromq 4.1.
 unstable-testing = ["compiletest_rs", "unstable"]
+static-libzmq = ["zmq-sys/static-libzmq"]
 
 [[example]]
 name = "rtdealer"

--- a/zmq-sys/Cargo.toml
+++ b/zmq-sys/Cargo.toml
@@ -22,3 +22,6 @@ glob = "0.2.11"
 
 [package.metadata.pkg-config]
 libzmq = "4.1"
+
+[features]
+static-libzmq = []

--- a/zmq-sys/Cargo.toml
+++ b/zmq-sys/Cargo.toml
@@ -16,7 +16,9 @@ links = "zmq"
 libc = "0.2.15"
 
 [build-dependencies]
+cmake = "0.1"
 metadeps = "1"
+glob = "0.2.11"
 
 [package.metadata.pkg-config]
 libzmq = "4.1"

--- a/zmq-sys/build.rs
+++ b/zmq-sys/build.rs
@@ -32,6 +32,11 @@ fn build_static_libzmq() {
         // When compiled on 64bit system then default libdir is `lib64`, with
         // this we ensure that libdir will be `lib` on all systems.
         .define("CMAKE_INSTALL_LIBDIR", "lib")
+        // libzmq is using C99 standard but they do not specify it in their
+        // cmake. This is needed when user has an older C compiler which the
+        // default standard is lower than C99.
+        // One valid scenario is cross-compilation for Linux embedded systems.
+        .define("CMAKE_C_STANDARD", "99")
         .define("ENABLE_DRAFTS", "OFF")
         .define("BUILD_SHARED", "OFF")
         .define("BUILD_STATIC", "ON")

--- a/zmq-sys/build.rs
+++ b/zmq-sys/build.rs
@@ -1,16 +1,70 @@
+#[cfg(windows)]
+extern crate cmake;
+#[cfg(windows)]
+use cmake::Config;
+
+#[cfg(windows)]
+extern crate glob;
+#[cfg(windows)]
+use glob::glob;
+
+#[cfg(not(windows))]
 extern crate metadeps;
-
+#[cfg(not(windows))]
 use std::env;
-use std::path::Path;
 
+use std::path::Path;
+use std::process::Command;
+
+#[cfg(windows)]
+fn main() {
+    if !Path::new("libzmq/.git").exists() {
+        let _ = Command::new("git")
+            .args(&["submodule", "update", "--init"])
+            .status();
+    }
+
+    let dst = Config::new("libzmq").build();
+
+    // Everything expects to link to zmq.lib, but the windows
+    // build outputs a bunch of libs depending on runtime,
+    // so we need to copy the one we want to the expected name.
+    //
+    // We use a glob pattern here so we don't have to worry about
+    // the actual Visual Studio or zmq versions.
+    let pattern = format!("{}\\libzmq-v???-mt-sgd-*.lib", dst.join("lib").display());
+    let found_path = glob(&pattern)
+        .expect("Failed to read file glob pattern.")
+        .next()
+        .expect("No appropriate file created by libzmq build. Build script is likely out of date.")
+        .unwrap();
+
+    let expected_path = dst.join("lib\\zmq.lib");
+    std::fs::copy(&found_path, &expected_path).expect(&format!(
+        "Unable to copy '{}' to '{}'",
+        found_path.display(),
+        expected_path.display()
+    ));
+
+    println!(
+        "cargo:rustc-link-search=native={}",
+        dst.join("lib").display()
+    );
+    println!("cargo:rustc-link-lib=static=zmq");
+    println!("cargo:rustc-link-lib=dylib=iphlpapi");
+}
+
+#[cfg(not(windows))]
 fn prefix_dir(env_name: &str, dir: &str) -> Option<String> {
     env::var(env_name).ok().or_else(|| {
-        env::var("LIBZMQ_PREFIX").ok()
+        env::var("LIBZMQ_PREFIX")
+            .ok()
             .map(|prefix| Path::new(&prefix).join(dir))
             .and_then(|path| path.to_str().map(|p| p.to_owned()))
     })
 }
 
+#[cfg(not(windows))]
 fn main() {
     let lib_path = prefix_dir("LIBZMQ_LIB_DIR", "lib");
     let include = prefix_dir("LIBZMQ_INCLUDE_DIR", "include");
@@ -20,12 +74,8 @@ fn main() {
             println!("cargo:rustc-link-search=native={}", lib_path);
             println!("cargo:include={}", include);
         }
-        (Some(_), None) => {
-            panic!("Unable to locate libzmq include directory.")
-        }
-        (None, Some(_)) => {
-            panic!("Unable to locate libzmq library directory.")
-        }
+        (Some(_), None) => panic!("Unable to locate libzmq include directory."),
+        (None, Some(_)) => panic!("Unable to locate libzmq library directory."),
         (None, None) => {
             if let Err(e) = metadeps::probe() {
                 panic!("Unable to locate libzmq:\n{}", e);

--- a/zmq-sys/build.rs
+++ b/zmq-sys/build.rs
@@ -37,6 +37,9 @@ fn build_static_libzmq() {
         .define("BUILD_STATIC", "ON")
         .build();
 
+    let lib_path = dst.join("lib");
+    let include_path = dst.join("include");
+
     if target.contains("msvc") {
         // Everything expects to link to zmq.lib, but the windows
         // build outputs a bunch of libs depending on runtime,
@@ -57,8 +60,7 @@ fn build_static_libzmq() {
             }
         };
 
-        let pattern = format!("{}", dst.join("lib").join(file_pattern).display());
-
+        let pattern = format!("{}", lib_path.join(file_pattern).display());
         let found_path = glob(&pattern)
             .expect("Failed to read file glob pattern.")
             .next()
@@ -67,7 +69,7 @@ fn build_static_libzmq() {
             )
             .unwrap();
 
-        let expected_path = dst.join("lib").join("zmq.lib");
+        let expected_path = lib_path.join("zmq.lib");
         std::fs::copy(&found_path, &expected_path).expect(&format!(
             "Unable to copy '{}' to '{}'",
             found_path.display(),
@@ -75,10 +77,9 @@ fn build_static_libzmq() {
         ));
     }
 
-    println!(
-        "cargo:rustc-link-search=native={}",
-        dst.join("lib").display()
-    );
+    println!("cargo:root={}", dst.display());
+    println!("cargo:include={}", include_path.display());
+    println!("cargo:rustc-link-search=native={}", lib_path.display());
     println!("cargo:rustc-link-lib=static=zmq");
 
     if target.contains("msvc") {


### PR DESCRIPTION
Since @zachlute is not that active I open this PR which contains his and my changes. This PR replaces #239.

This PR introduces a crate feature `static-libzmq` which builds libzmq and statically links it to the binary.
This makes it easier for the users to use zmq crate without building libzmq on their own. It is tested on Windows and Linux. It is also tested in Linux embedded environments that cross-compilation is a must.
Users are required to have cmake installed.

Let know what improvements/changes you may need.