### PR TITLE
Update crate dependencies

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,8 +29,6 @@ matrix:
     - rust: nightly
       script:
         - cargo test --verbose --all-targets
-        - cargo clean # needed due to compiletests-rs issues
-        - cargo test --verbose --features unstable-testing
 
     - rust: nightly
       env: CLIPPY

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -77,10 +77,8 @@ name = "weather_server"
 path = "examples/zguide/weather_server/main.rs"
 
 [features]
-unstable = []
 default = ["zmq_has"]
 zmq_has = [] # zmq_has was added in zeromq 4.1.
-unstable-testing = ["compiletest_rs", "unstable"]
 
 [[example]]
 name = "rtdealer"
@@ -158,16 +156,16 @@ path="examples/zguide/asyncsrv/main.rs"
 libc = "0.2.15"
 log = "0.4.3"
 zmq-sys = { version = "0.9.0", path = "zmq-sys" }
-compiletest_rs = { version = "0.3", optional = true }
-bitflags = "0.7"
+bitflags = "1.0"
 
 [build-dependencies]
 zmq-sys = { version = "0.9.0", path = "zmq-sys" }
 
 [dev-dependencies]
-env_logger = "0.5"
-quickcheck = "0.6"
-rand = "0.5"
+env_logger = "0.6"
+quickcheck = "0.8"
+rand = "0.6"
 tempfile = "3"
 timebomb = "0.1.2"
-nix = "0.11"
+nix = "0.13"
+compiletest_rs = { version = "0.3.10", features = ["stable"] }

--- a/examples/zguide/pathopub/main.rs
+++ b/examples/zguide/pathopub/main.rs
@@ -7,7 +7,7 @@ use std::env;
 use std::thread::sleep;
 use std::time::Duration;
 
-use rand::distributions::{Distribution, Range};
+use rand::distributions::{Distribution, Uniform};
 
 fn main() {
     let context = zmq::Context::new();
@@ -34,7 +34,7 @@ fn main() {
     }
     // Send one random update per second
     let mut rng = rand::thread_rng();
-    let topic_range = Range::new(0, 1000);
+    let topic_range = Uniform::new(0, 1000);
     loop {
         sleep(Duration::from_millis(1000));
         publisher

--- a/examples/zguide/pathosub/main.rs
+++ b/examples/zguide/pathosub/main.rs
@@ -6,7 +6,7 @@ extern crate zmq;
 
 use std::env;
 
-use rand::distributions::{Distribution, Range};
+use rand::distributions::{Distribution, Uniform};
 
 fn main() {
     let context = zmq::Context::new();
@@ -23,7 +23,7 @@ fn main() {
         .expect("could not connect to publisher");
 
     let mut rng = rand::thread_rng();
-    let topic_range = Range::new(0, 1000);
+    let topic_range = Uniform::new(0, 1000);
     let subscription = format!("{:03}", topic_range.sample(&mut rng)).into_bytes();
     subscriber.set_subscribe(&subscription).unwrap();
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,5 @@
 //! Module: zmq
 
-#![cfg_attr(feature = "unstable", feature(plugin))]
 #![allow(trivial_numeric_casts)]
 
 #[macro_use]
@@ -1020,19 +1019,31 @@ impl Socket {
 
 bitflags! {
     /// Type representing pending socket events.
-    pub flags PollEvents: i16 {
+    pub struct PollEvents: i16 {
         /// For `poll()`, specifies to signal when a message/some data
         /// can be read from a socket.
-        const POLLIN = 1,
+        const POLLIN = 1;
         /// For `poll()`, specifies to signal when a message/some data
         /// can be written to a socket.
-        const POLLOUT = 2,
+        const POLLOUT = 2;
         /// For `poll()`, specifies to signal when an error condition
         /// is present on a socket.  This only applies to non-0MQ
         /// sockets.
-        const POLLERR = 4,
+        const POLLERR = 4;
     }
 }
+
+/// For `poll()`, specifies to signal when a message/some data can be
+/// read from a socket.
+pub const POLLIN: PollEvents = PollEvents::POLLIN;
+
+/// For `poll()`, specifies to signal when a message/some data can be
+/// written to a socket.
+pub const POLLOUT: PollEvents = PollEvents::POLLOUT;
+
+/// For `poll()`, specifies to signal when an error condition is
+/// present on a socket.  This only applies to non-0MQ sockets.
+pub const POLLERR: PollEvents = PollEvents::POLLERR;
 
 /// Represents a handle that can be `poll()`ed.
 ///

--- a/tests/compile-tests.rs
+++ b/tests/compile-tests.rs
@@ -1,5 +1,3 @@
-#![cfg(feature = "unstable-testing")]
-
 extern crate compiletest_rs as compiletest;
 
 use std::env::var;

--- a/tests/z85.rs
+++ b/tests/z85.rs
@@ -1,9 +1,13 @@
+extern crate rand;
 extern crate zmq;
 
 #[macro_use]
 extern crate quickcheck;
 
+use std::iter;
+
 use quickcheck::{Arbitrary, Gen};
+use rand::Rng;
 use zmq::{z85_decode, z85_encode, DecodeError, EncodeError};
 
 #[test]
@@ -43,7 +47,7 @@ struct Input(Vec<u8>);
 impl Arbitrary for Input {
     fn arbitrary<G: Gen>(g: &mut G) -> Self {
         let len = g.gen_range(0, 256) * 4;
-        Input(g.gen_iter::<u8>().take(len).collect())
+        Input(iter::repeat(()).map(|_| g.gen()).take(len).collect())
     }
 }
 


### PR DESCRIPTION
- The `compiletest_rs` crate now works on stable Rust, so remove the
  `unstable-testing` feature, and run always run the compile
  tests. The feature removal is, strictly speaking, a breaking change,
  but can be arguably be justified to be non-breaking for normal
  users, as it is not a feature to be enabled by dependant crates. In
  the same vein, the `unstable` feature has been removed, which seemed
  to be an unused leftover.

- The `bitflags` crate had changes in the syntax and semantics of the
  `bitflags` macro, requiring adding top-level constants for `POLLIN`,
  `POLLOUT` and `POLLERR` to maintain backward compatibility.

- The `rand` crate had some breaking changes between 0.5 and 0.6,
  which required some small changes in the test suite.