### PR TITLE
Build zeromq from source via zeromq-src-rs

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,29 @@ readme = "README.md"
 build = "build.rs"
 edition = "2018"
 
+[features]
+default = ["zmq_has"]
+zmq_has = [] # zmq_has was added in zeromq 4.1.
+vendored = ['zmq-sys/vendored']
+
+[dependencies]
+libc = "0.2.15"
+log = "0.4.3"
+zmq-sys = { version = "0.9.0", path = "zmq-sys" }
+bitflags = "1.0"
+
+[build-dependencies]
+zmq-sys = { version = "0.9.0", path = "zmq-sys" }
+
+[dev-dependencies]
+env_logger = "0.6"
+quickcheck = "0.8"
+rand = "0.6"
+tempfile = "3"
+timebomb = "0.1.2"
+nix = "0.13"
+compiletest_rs = { version = "0.3.10", features = ["stable"] }
+
 [[example]]
 name = "helloworld_client"
 path = "examples/zguide/helloworld_client/main.rs"
@@ -76,10 +99,6 @@ path = "examples/zguide/weather_client/main.rs"
 [[example]]
 name = "weather_server"
 path = "examples/zguide/weather_server/main.rs"
-
-[features]
-default = ["zmq_has"]
-zmq_has = [] # zmq_has was added in zeromq 4.1.
 
 [[example]]
 name = "rtdealer"
@@ -152,21 +171,3 @@ path="examples/zguide/lbbroker/main.rs"
 [[example]]
 name="asyncsrv"
 path="examples/zguide/asyncsrv/main.rs"
-
-[dependencies]
-libc = "0.2.15"
-log = "0.4.3"
-zmq-sys = { version = "0.9.0", path = "zmq-sys" }
-bitflags = "1.0"
-
-[build-dependencies]
-zmq-sys = { version = "0.9.0", path = "zmq-sys" }
-
-[dev-dependencies]
-env_logger = "0.6"
-quickcheck = "0.8"
-rand = "0.6"
-tempfile = "3"
-timebomb = "0.1.2"
-nix = "0.13"
-compiletest_rs = { version = "0.3.10", features = ["stable"] }

--- a/zmq-sys/Cargo.toml
+++ b/zmq-sys/Cargo.toml
@@ -23,7 +23,7 @@ libc = "0.2.15"
 
 [build-dependencies]
 metadeps = "1"
-zeromq-src = { version = "0.1.1", optional = true }
+zeromq-src = { version = "0.1.2", optional = true }
 
 [package.metadata.pkg-config]
 libzmq = "4.1"

--- a/zmq-sys/Cargo.toml
+++ b/zmq-sys/Cargo.toml
@@ -15,8 +15,6 @@ links = "zmq"
 [features]
 # Build libzmq from source.
 vendored = ['zeromq-src']
-# Build and link the vendored lib statically.
-static = []
 
 [dependencies]
 libc = "0.2.15"

--- a/zmq-sys/Cargo.toml
+++ b/zmq-sys/Cargo.toml
@@ -9,14 +9,21 @@ license = "MIT/Apache-2.0"
 description = "Low-level bindings to the zeromq library"
 keywords = ["ffi", "bindings"]
 repository = "https://github.com/erickt/rust-zmq"
-build = "build.rs"
+build = "build/main.rs"
 links = "zmq"
+
+[features]
+# Build libzmq from source.
+vendored = ['zeromq-src']
+# Build and link the vendored lib statically.
+static = []
 
 [dependencies]
 libc = "0.2.15"
 
 [build-dependencies]
 metadeps = "1"
+zeromq-src = { version = "0.1.1", optional = true }
 
 [package.metadata.pkg-config]
 libzmq = "4.1"

--- a/zmq-sys/build/main.rs
+++ b/zmq-sys/build/main.rs
@@ -1,0 +1,7 @@
+#[cfg_attr(feature = "vendored", path = "vendored.rs")]
+#[cfg_attr(not(feature = "vendored"), path = "pkg_config.rs")]
+mod find;
+
+fn main() {
+    find::configure()
+}

--- a/zmq-sys/build/pkg_config.rs
+++ b/zmq-sys/build/pkg_config.rs
@@ -1,7 +1,4 @@
-extern crate metadeps;
-
-use std::env;
-use std::path::Path;
+use std::{env, path::Path};
 
 fn prefix_dir(env_name: &str, dir: &str) -> Option<String> {
     env::var(env_name).ok().or_else(|| {

--- a/zmq-sys/build/pkg_config.rs
+++ b/zmq-sys/build/pkg_config.rs
@@ -5,13 +5,14 @@ use std::path::Path;
 
 fn prefix_dir(env_name: &str, dir: &str) -> Option<String> {
     env::var(env_name).ok().or_else(|| {
-        env::var("LIBZMQ_PREFIX").ok()
+        env::var("LIBZMQ_PREFIX")
+            .ok()
             .map(|prefix| Path::new(&prefix).join(dir))
             .and_then(|path| path.to_str().map(|p| p.to_owned()))
     })
 }
 
-fn main() {
+pub fn configure() {
     let lib_path = prefix_dir("LIBZMQ_LIB_DIR", "lib");
     let include = prefix_dir("LIBZMQ_INCLUDE_DIR", "include");
 
@@ -20,12 +21,8 @@ fn main() {
             println!("cargo:rustc-link-search=native={}", lib_path);
             println!("cargo:include={}", include);
         }
-        (Some(_), None) => {
-            panic!("Unable to locate libzmq include directory.")
-        }
-        (None, Some(_)) => {
-            panic!("Unable to locate libzmq library directory.")
-        }
+        (Some(_), None) => panic!("Unable to locate libzmq include directory."),
+        (None, Some(_)) => panic!("Unable to locate libzmq library directory."),
         (None, None) => {
             if let Err(e) = metadeps::probe() {
                 panic!("Unable to locate libzmq:\n{}", e);

--- a/zmq-sys/build/vendored.rs
+++ b/zmq-sys/build/vendored.rs
@@ -1,13 +1,8 @@
-use std::env;
-
 pub fn configure() {
-    let wants_static =
-        cfg!(feature = "static") || env::var("ZMQ_SYS_STATIC").unwrap_or_default() == "1";
-
     // Whether the current profile is in debug.
     let wants_debug = cfg!(debug_assertions);
 
     println!("cargo:rerun-if-changed=build.rs");
-    let artifacts = zeromq_src::Build::new().link_static(wants_static).build_debug(wants_debug).build();
+    let artifacts = zeromq_src::Build::new().link_static(true).build_debug(wants_debug).build();
     artifacts.print_cargo_metadata();
 }

--- a/zmq-sys/build/vendored.rs
+++ b/zmq-sys/build/vendored.rs
@@ -4,7 +4,10 @@ pub fn configure() {
     let wants_static =
         cfg!(feature = "static") || env::var("ZMQ_SYS_STATIC").unwrap_or_default() == "1";
 
+    // Whether the current profile is in debug.
+    let wants_debug = cfg!(debug_assertions);
+
     println!("cargo:rerun-if-changed=build.rs");
-    let artifacts = zeromq_src::Build::new().link_static(wants_static).build();
+    let artifacts = zeromq_src::Build::new().link_static(wants_static).build_debug(wants_debug).build();
     artifacts.print_cargo_metadata();
 }

--- a/zmq-sys/build/vendored.rs
+++ b/zmq-sys/build/vendored.rs
@@ -1,0 +1,10 @@
+use std::env;
+
+pub fn configure() {
+    let wants_static =
+        cfg!(feature = "static") || env::var("ZMQ_SYS_STATIC").unwrap_or_default() == "1";
+
+    println!("cargo:rerun-if-changed=build.rs");
+    let artifacts = zeromq_src::Build::new().link_static(wants_static).build();
+    artifacts.print_cargo_metadata();
+}


### PR DESCRIPTION
~~Also fixed improperly formatted files.~~

This would fix #257, at least the building from source part. Also related to #241.

This uses [zeromq-src](https://github.com/jean-airoldie/zeromq-src-rs) for the source code and the tooling.

I do not know if this builds in windows, since it only tested on ubuntu xenial and fedora 29.