### PR TITLE
CI: Update travis build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,15 @@
 language: rust
+rust:
+  - 1.32.0 # uniform paths
+  - stable
+  - beta
+  - nightly
+os: linux
+
+# always test things that aren't pushes (like PRs)
+# never test tags or pushes to non-master or release branches (wait for PR)
+# https://github.com/travis-ci/travis-ci/issues/2200#issuecomment-441395545)
+if: type != push OR (tag IS blank AND branch =~ /^(master|release\/-.*)$/)
 
 addons:
   apt:
@@ -17,29 +28,29 @@ before_install:
   - cd zeromq-4.2.5 && ./configure --prefix=$HOME --with-libsodium && make && make install && cd ..
 
 matrix:
-  include:
-    - rust: stable
-      script:
-        - cargo test --verbose --all-targets
-
-    - rust: beta
-      script:
-        - cargo test --verbose --all-targets
-
-    - rust: nightly
-      script:
-        - cargo test --verbose --all-targets
-
-    - rust: nightly
-      env: CLIPPY
-      script:
-        - rustup component add clippy-preview || travis_terminate 0
-        - cargo clippy -- -D clippy::all
-        - cargo clippy --all-targets --all-features -- -D clippy::all
-
   allow_failures:
     - rust: nightly
-      env: CLIPPY
+  fast_finish: true
+  include:
+    - stage: check # do a pre-screen to make sure this is even worth testing
+      script: cargo check --all-targets
+      rust: stable
+    - stage: lint
+      name: "Rust: rustfmt"
+      install:
+        - rustup component add rustfmt
+      script:
+        - cargo fmt -v -- --check
+    - name: "Rust: clippy"
+      install:
+        - rustup component add clippy
+      script:
+        - cargo clippy --all-features --all-targets -- -D warnings
+
+stages:
+  - check
+  - test
+  - lint
 
 env:
   global:

--- a/examples/zguide/lbbroker/main.rs
+++ b/examples/zguide/lbbroker/main.rs
@@ -120,7 +120,8 @@ fn main() {
         let rc = zmq::poll(
             &mut items[0..if worker_queue.is_empty() { 1 } else { 2 }],
             -1,
-        ).unwrap();
+        )
+        .unwrap();
 
         if rc == -1 {
             break;

--- a/examples/zguide/monitor/main.rs
+++ b/examples/zguide/monitor/main.rs
@@ -71,16 +71,12 @@ fn main() {
         .expect_err("Socket monitoring only works over inproc://");
     assert_eq!(zmq::Error::EPROTONOSUPPORT, err);
 
-    assert!(
-        client
-            .monitor("inproc://monitor-client", zmq::SocketEvent::ALL as i32)
-            .is_ok()
-    );
-    assert!(
-        server
-            .monitor("inproc://monitor-server", zmq::SocketEvent::ALL as i32)
-            .is_ok()
-    );
+    assert!(client
+        .monitor("inproc://monitor-client", zmq::SocketEvent::ALL as i32)
+        .is_ok());
+    assert!(server
+        .monitor("inproc://monitor-server", zmq::SocketEvent::ALL as i32)
+        .is_ok());
 
     let mut client_mon = ctx.socket(zmq::PAIR).unwrap();
     let mut server_mon = ctx.socket(zmq::PAIR).unwrap();

--- a/examples/zguide/pathopub/main.rs
+++ b/examples/zguide/pathopub/main.rs
@@ -41,7 +41,8 @@ fn main() {
             .send(
                 &format!("{:03}", topic_range.sample(&mut rng)),
                 zmq::SNDMORE,
-            ).unwrap();
+            )
+            .unwrap();
         publisher.send("Off with his head!", 0).unwrap();
     }
 }


### PR DESCRIPTION
- Ensure compatibility back to rustc 1.32
- Run `cargo check` upfront, before running the full matrix
- Do a staged build (check, test, lint)
- Include running a rustfmt check in the lint phase (fixes #263)