### PR TITLE
Added vendored build support

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -3,7 +3,7 @@ os:
 clone_depth: 1
 configuration:
   - Debug
-    #  - Release
+  - Release
 platform:
   #- Win32
   - x64

--- a/.appveyor/appveyor.bat
+++ b/.appveyor/appveyor.bat
@@ -110,8 +110,11 @@ cargo --version
 
 set RUST_BACKTRACE=1
 
-cargo build -vv %CARGO_MODE%
+cargo test -vv %CARGO_MODE%
 if %ERRORLEVEL% NEQ 0 exit 1
 
-cargo test -vv %CARGO_MODE%
+cargo clean %CARGO_MODE%
+if %ERRORLEVEL% NEQ 0 exit 1
+
+cargo test -vv --all-features %CARGO_MODE%
 if %ERRORLEVEL% NEQ 0 exit 1

--- a/.travis.yml
+++ b/.travis.yml
@@ -35,6 +35,13 @@ matrix:
     - stage: check # do a pre-screen to make sure this is even worth testing
       script: cargo check --all-targets
       rust: stable
+    - stage: test
+      script:
+        - cargo test --all
+        # Now test with the vendored crate. Clean to prevent duplicate zmq link.
+        - cargo clean
+        - cargo test --all --all-features
+        - cargo test --all --release --all-features
     - stage: lint
       name: "Rust: rustfmt"
       install:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,32 @@ readme = "README.md"
 build = "build.rs"
 edition = "2018"
 
+[features]
+default = ["zmq_has"]
+# zmq_has was added in zeromq 4.1. As we now require 4.1 or newer,
+# this feature is a no-op and only present for backward-compatibility;
+# it will be removed in the next API-breaking release.
+zmq_has = []
+vendored = ['zmq-sys/vendored']
+
+[dependencies]
+libc = "0.2.15"
+log = "0.4.3"
+zmq-sys = { version = "0.9.0", path = "zmq-sys" }
+bitflags = "1.0"
+
+[build-dependencies]
+zmq-sys = { version = "0.9.0", path = "zmq-sys" }
+
+[dev-dependencies]
+env_logger = "0.6"
+quickcheck = "0.8"
+rand = "0.6"
+tempfile = "3"
+timebomb = "0.1.2"
+nix = "0.13"
+compiletest_rs = { version = "0.3.10", features = ["stable"] }
+
 [[example]]
 name = "helloworld_client"
 path = "examples/zguide/helloworld_client/main.rs"
@@ -76,13 +102,6 @@ path = "examples/zguide/weather_client/main.rs"
 [[example]]
 name = "weather_server"
 path = "examples/zguide/weather_server/main.rs"
-
-[features]
-default = ["zmq_has"]
-# zmq_has was added in zeromq 4.1. As we now require 4.1 or newer,
-# this feature is a no-op and only present for backward-compatibility;
-# it will be removed in the next API-breaking release.
-zmq_has = []
 
 [[example]]
 name = "rtdealer"
@@ -155,21 +174,3 @@ path="examples/zguide/lbbroker/main.rs"
 [[example]]
 name="asyncsrv"
 path="examples/zguide/asyncsrv/main.rs"
-
-[dependencies]
-libc = "0.2.15"
-log = "0.4.3"
-zmq-sys = { version = "0.9.0", path = "zmq-sys" }
-bitflags = "1.0"
-
-[build-dependencies]
-zmq-sys = { version = "0.9.0", path = "zmq-sys" }
-
-[dev-dependencies]
-env_logger = "0.6"
-quickcheck = "0.8"
-rand = "0.6"
-tempfile = "3"
-timebomb = "0.1.2"
-nix = "0.13"
-compiletest_rs = { version = "0.3.10", features = ["stable"] }

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,11 @@
+# 0.9.1
+
+## New and improved functionality
+
+- Added `vendored` feature which build `libzmq` from source via [`zeromq-src`].
+
+[`zeromq-src`]: https://github.com/jean-airoldie/zeromq-src-rs
+
 # 0.9.0
 
 This release will focus on API corrections and improving

--- a/zmq-sys/Cargo.toml
+++ b/zmq-sys/Cargo.toml
@@ -21,7 +21,7 @@ libc = "0.2.15"
 
 [build-dependencies]
 metadeps = "1"
-zeromq-src = { version = "0.1.5", optional = true }
+zeromq-src = { version = "0.1.6", optional = true }
 
 [package.metadata.pkg-config]
 libzmq = "4.1"

--- a/zmq-sys/Cargo.toml
+++ b/zmq-sys/Cargo.toml
@@ -9,14 +9,19 @@ license = "MIT/Apache-2.0"
 description = "Low-level bindings to the zeromq library"
 keywords = ["ffi", "bindings"]
 repository = "https://github.com/erickt/rust-zmq"
-build = "build.rs"
+build = "build/main.rs"
 links = "zmq"
+
+[features]
+# Build libzmq from source.
+vendored = ['zeromq-src']
 
 [dependencies]
 libc = "0.2.15"
 
 [build-dependencies]
 metadeps = "1"
+zeromq-src = { version = "0.1.5", optional = true }
 
 [package.metadata.pkg-config]
 libzmq = "4.1"

--- a/zmq-sys/build/main.rs
+++ b/zmq-sys/build/main.rs
@@ -1,0 +1,7 @@
+#[cfg_attr(feature = "vendored", path = "vendored.rs")]
+#[cfg_attr(not(feature = "vendored"), path = "pkg_config.rs")]
+mod find;
+
+fn main() {
+    find::configure()
+}

--- a/zmq-sys/build/pkg_config.rs
+++ b/zmq-sys/build/pkg_config.rs
@@ -1,17 +1,15 @@
-extern crate metadeps;
-
-use std::env;
-use std::path::Path;
+use std::{env, path::Path};
 
 fn prefix_dir(env_name: &str, dir: &str) -> Option<String> {
     env::var(env_name).ok().or_else(|| {
-        env::var("LIBZMQ_PREFIX").ok()
+        env::var("LIBZMQ_PREFIX")
+            .ok()
             .map(|prefix| Path::new(&prefix).join(dir))
             .and_then(|path| path.to_str().map(|p| p.to_owned()))
     })
 }
 
-fn main() {
+pub fn configure() {
     let lib_path = prefix_dir("LIBZMQ_LIB_DIR", "lib");
     let include = prefix_dir("LIBZMQ_INCLUDE_DIR", "include");
 
@@ -20,12 +18,8 @@ fn main() {
             println!("cargo:rustc-link-search=native={}", lib_path);
             println!("cargo:include={}", include);
         }
-        (Some(_), None) => {
-            panic!("Unable to locate libzmq include directory.")
-        }
-        (None, Some(_)) => {
-            panic!("Unable to locate libzmq library directory.")
-        }
+        (Some(_), None) => panic!("Unable to locate libzmq include directory."),
+        (None, Some(_)) => panic!("Unable to locate libzmq library directory."),
         (None, None) => {
             if let Err(e) = metadeps::probe() {
                 panic!("Unable to locate libzmq:\n{}", e);

--- a/zmq-sys/build/vendored.rs
+++ b/zmq-sys/build/vendored.rs
@@ -1,0 +1,8 @@
+pub fn configure() {
+    // Whether the current profile is in debug.
+    let wants_debug = cfg!(debug_assertions);
+
+    println!("cargo:rerun-if-changed=build.rs");
+    let artifacts = zeromq_src::Build::new().link_static(true).build_debug(wants_debug).build();
+    artifacts.print_cargo_metadata();
+}

--- a/zmq-sys/build/vendored.rs
+++ b/zmq-sys/build/vendored.rs
@@ -1,8 +1,11 @@
-pub fn configure() {
-    // Whether the current profile is in debug.
-    let wants_debug = cfg!(debug_assertions);
+use std::env;
 
+pub fn configure() {
     println!("cargo:rerun-if-changed=build.rs");
+    println!("cargo:rerun-if-env-changed=PROFILE");
+
+    let wants_debug = env::var("PROFILE").unwrap() == "debug";
+
     let artifacts = zeromq_src::Build::new().link_static(true).build_debug(wants_debug).build();
     artifacts.print_cargo_metadata();
 }


### PR DESCRIPTION
This is the reopening of #262 since github does not allow the reopening of PRs after you force push.

The vendored crate now compiles statically, adding dynamic compilation down the line would be trivial.