### PR TITLE
Fix `compile_test` for release mode

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -1,6 +1,13 @@
+use std::env;
+
 #[cfg(feature = "zmq_has")]
 fn main() {
     use std::ffi::CString;
+
+    println!(
+        "cargo:rustc-env=BUILD_PROFILE={}",
+        env::var("PROFILE").unwrap()
+    );
 
     for has in ["ipc", "pgm", "tipc", "norm", "curve", "gssapi"].into_iter() {
         if unsafe { zmq_sys::zmq_has(CString::new(has.as_bytes()).unwrap().as_ptr()) } == 1 {
@@ -13,6 +20,11 @@ fn main() {
 fn main() {
     use std::mem::size_of;
     use std::os::raw::c_int;
+
+    println!(
+        "cargo:rustc-env=BUILD_PROFILE={}",
+        env::var("PROFILE").unwrap()
+    );
 
     const ZMQ_CURVE_SERVER: c_int = 47;
     const ZMQ_GSSAPI_SERVER: c_int = 62;

--- a/tests/compile-tests.rs
+++ b/tests/compile-tests.rs
@@ -6,7 +6,11 @@ fn run_mode(mode: &'static str) {
 
     let cfg_mode = mode.parse().expect("Invalid mode");
 
-    config.target_rustcflags = Some("-L target/debug/ -L target/debug/deps/".to_owned());
+    config.target_rustcflags = Some(format!(
+        "-L target/{profile} -L target/{profile}/deps",
+        profile = env!("BUILD_PROFILE")
+    ));
+
     if let Ok(name) = var::<&str>("TESTNAME") {
         let s: String = name.to_owned();
         config.filter = Some(s)


### PR DESCRIPTION
The following was failing:

```
cargo clean
cargo test --release
```