### PR TITLE
Deprecate several `Message` methods

### DIFF
--- a/tests/curve.rs
+++ b/tests/curve.rs
@@ -1,7 +1,7 @@
 #[macro_use]
 mod common;
 
-use zmq::{Context, CurveKeyPair, Message, Socket};
+use zmq::{Context, CurveKeyPair, Socket};
 
 fn create_socketpair() -> (Socket, Socket) {
     let ctx = Context::default();
@@ -36,7 +36,6 @@ test!(test_curve_messages, {
     println!("this is it {0}", msg.as_str().unwrap());
     assert_eq!(format!("{:?}", msg), "[102, 111, 111]");
     receiver.send("bar", 0).unwrap();
-    let mut msg = Message::with_capacity(1);
-    sender.recv(&mut msg, 0).unwrap();
+    let msg = sender.recv_msg(0).unwrap();
     assert_eq!(&msg[..], b"bar");
 });

--- a/tests/message.rs
+++ b/tests/message.rs
@@ -21,15 +21,15 @@ where
 
 quickcheck! {
     fn msg_cmp_eq(input: Vec<u8>) -> bool {
-        Message::from_slice(&input) == Message::from_slice(&input)
+        Message::from(&input) == Message::from(&input)
     }
 
     fn msg_cmp_ne(input: NePair<Vec<u8>>) -> bool {
-        Message::from_slice(&input.0) != Message::from_slice(&input.1)
+        Message::from(&input.0) != Message::from(&input.1)
     }
 
     fn msg_vec_roundtrip(input: Vec<u8>) -> bool {
-        let original = Message::from_slice(&input.clone());
+        let original = Message::from(&input.clone());
         Message::from(input) == original
     }
 }

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -41,8 +41,7 @@ test!(test_exchanging_messages, {
     assert_eq!(format!("{:?}", msg), "[102, 111, 111]");
 
     receiver.send("bar", 0).unwrap();
-    let mut msg = Message::with_capacity(1);
-    sender.recv(&mut msg, 0).unwrap();
+    let msg = sender.recv_msg(0).unwrap();
     assert_eq!(&msg[..], b"bar");
 });
 


### PR DESCRIPTION
The `with_capacity_unallocated`, `with_capacity` and `from_slice`
methods are deprecated, the first one without a planned alternative.