### PR TITLE
Bumped zeromq-src dependency to 0.1.7

### DIFF
--- a/zmq-sys/Cargo.toml
+++ b/zmq-sys/Cargo.toml
@@ -22,7 +22,7 @@ libc = "0.2.15"
 
 [build-dependencies]
 metadeps = "1"
-zeromq-src = { version = "0.1.6", optional = true }
+zeromq-src = { version = "0.1.7", optional = true }
 
 [package.metadata.pkg-config]
 libzmq = "4.1"


### PR DESCRIPTION
Fixes #283.

I know that `0.1.6` is equivalent to `^0.1.6`, so this is not strictly needed, but we are never too safe.