### PR TITLE
Fix clippy warnings

### DIFF
--- a/examples/zguide/fileio3/main.rs
+++ b/examples/zguide/fileio3/main.rs
@@ -14,7 +14,7 @@ use tempfile::tempfile;
 use zmq::SNDMORE;
 
 static CHUNK_SIZE: usize = 250_000;
-static CHUNK_SIZE_STR: &'static str = "250000";
+static CHUNK_SIZE_STR: &str = "250000";
 static PIPELINE: usize = 10;
 static PIPELINE_HWM: usize = 20;
 

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -2,9 +2,9 @@
 
 pub extern crate timebomb;
 
-use std::sync::{Once, ONCE_INIT};
+use std::sync::Once;
 
-static LOGGER_INIT: Once = ONCE_INIT;
+static LOGGER_INIT: Once = Once::new();
 
 #[macro_export]
 macro_rules! test {


### PR DESCRIPTION
These were identified by current beta clippy (1.38):

- `ONCE_INIT` is now deprecated.
- Superfluous `'static` lifetime on static variable.