### PR TITLE
Problem: denial-of-service in Message::gets

### DIFF
--- a/src/message.rs
+++ b/src/message.rs
@@ -124,7 +124,7 @@ impl Message {
         if value.is_null() {
             None
         } else {
-            Some(unsafe { str::from_utf8(ffi::CStr::from_ptr(value).to_bytes()).unwrap() })
+            str::from_utf8(unsafe { ffi::CStr::from_ptr(value) }.to_bytes()).ok()
         }
     }
 }


### PR DESCRIPTION
Solution: return None on invalid UTF-8 instead of panicking.

The doc for zmq_msg_gets says that "both the property argument and the
value shall be NULL-terminated UTF8-strings", but in practice libzmq
neither confirms nor enforces this. A buggy or malicious peer can send
arbitrary binary garbage, which will be faithfully returned verbatim
from zmq_msg_gets. Converting the Result from str::from_utf8 to an
Option via .ok() instead of unwrapping saves us from a crash without a
client-breaking type change.