### PR TITLE
Remove log code from library

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,11 +29,11 @@ vendored = ['zmq-sys/vendored']
 
 [dependencies]
 libc = "0.2.15"
-log = "0.4.3"
 zmq-sys = { version = "0.11.0", path = "zmq-sys" }
 bitflags = "1.0"
 
 [dev-dependencies]
+log = "0.4.3"
 env_logger = "0.6"
 quickcheck = "0.9"
 rand = "0.7"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,7 +4,6 @@
 
 use bitflags::bitflags;
 use libc::{c_int, c_long, c_short};
-use log::debug;
 
 use std::ffi;
 use std::fmt;
@@ -393,7 +392,6 @@ unsafe impl Sync for RawContext {}
 
 impl Drop for RawContext {
     fn drop(&mut self) {
-        debug!("context dropped");
         let mut e = self.term();
         while e == Err(Error::EINTR) {
             e = self.term();
@@ -485,8 +483,6 @@ impl Drop for Socket {
         if self.owned {
             if unsafe { zmq_sys::zmq_close(self.sock) } == -1 {
                 panic!(errno_to_error());
-            } else {
-                debug!("socket dropped");
             }
         }
     }


### PR DESCRIPTION
When using rust-zmq in an application, I noticed some log entries when dropping sockets. IMO this doesn't provide any useful information, so I removed it here. If you don't agree with this, just close the PR :)

Logging isn't used anywhere else in the library code, so this change also allows removing the dependency on the `log` crate from the non-dev section.