### PR TITLE
PollItem: Support checking associated socket

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1059,6 +1059,16 @@ impl<'a> PollItem<'a> {
     pub fn is_error(&self) -> bool {
         (self.revents & POLLERR.bits()) != 0
     }
+
+    /// Returns true if the polled socket is the given 0MQ socket.
+    pub fn has_socket(&self, socket: &Socket) -> bool {
+        self.socket == socket.sock
+    }
+
+    /// Returns true if the polled socket is the given file descriptor.
+    pub fn has_fd(&self, fd: RawFd) -> bool {
+        self.socket.is_null() && self.fd == fd
+    }
 }
 
 /// Poll for events on multiple sockets.

--- a/tests/poll/unix.rs
+++ b/tests/poll/unix.rs
@@ -12,6 +12,7 @@ fn test_pipe_poll() {
         pipe_writer(pipe_write);
     });
     let pipe_item = zmq::PollItem::from_fd(pipe_read, zmq::POLLIN);
+    assert!(pipe_item.has_fd(pipe_read));
 
     let mut poll_items = [pipe_item];
     assert_eq!(zmq::poll(&mut poll_items, 1000).unwrap(), 1);

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -98,6 +98,11 @@ test!(test_polling, {
     let mut poll_items = vec![receiver.as_poll_item(POLLIN)];
     assert_eq!(poll(&mut poll_items, 1000).unwrap(), 1);
     assert_eq!(poll_items[0].get_revents(), POLLIN);
+    assert!(poll_items[0].is_readable());
+    assert!(!poll_items[0].is_writable());
+    assert!(!poll_items[0].is_error());
+    assert!(poll_items[0].has_socket(&receiver));
+    assert!(!poll_items[0].has_fd(0));
 });
 
 test!(test_raw_roundtrip, {


### PR DESCRIPTION
Adds is_socket and is_fd to PollItem to allow checking which socket a
PollItem has been created from.

Enables some use cases related to #68.