### PR TITLE
Attempt to fix the CI build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@
 *.a
 /target/
 Cargo.lock
+/msrv-test/target/

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 language: rust
 rust:
-  - 1.32.0 # uniform paths
   - stable
   - beta
   - nightly
@@ -42,6 +41,10 @@ matrix:
         - cargo clean
         - cargo test --all --all-features
         - cargo test --all --release --all-features
+    - name: "MSRV (1.32.0) compile check"
+      rust: 1.32.0 # uniform paths
+      script:
+        - cd msrv-test && cargo build
     - stage: lint
       name: "Rust: rustfmt"
       rust: stable

--- a/README.md
+++ b/README.md
@@ -34,6 +34,12 @@ draft API features, have a look at
 The current 0.9 release series requires `libzmq` 4.1 or newer. New
 release series of `zmq` may require newer `libzmq` versions.
 
+Regarding the minimum Rust version required, `zmq` is CI-tested on
+current stable, beta and nightly channels of Rust. Additionally, it is
+made sure that the code still compiles on Rust 1.32.0. However, no
+tests are run for that build, so use `zmq` on older Rust versions on
+your own risk. It is however likely that it will just work anyways.
+
 # Installation
 
 rust-zmq is available from [crates.io](https://crates.io). Users
@@ -123,7 +129,7 @@ need set `LIBZMQ_PREFIX` as described above.
 fn main() {
     let ctx = zmq::Context::new();
 
-    let mut socket = ctx.socket(zmq::REQ).unwrap();
+    let socket = ctx.socket(zmq::REQ).unwrap();
     socket.connect("tcp://127.0.0.1:1234").unwrap();
     socket.send("hello world!", 0).unwrap();
 }

--- a/examples/zguide/mtrelay/main.rs
+++ b/examples/zguide/mtrelay/main.rs
@@ -41,8 +41,7 @@ fn main() {
     receiver
         .bind("inproc://step3")
         .expect("failed binding step 3");
-    let ctx = context.clone();
-    thread::spawn(move || step2(&ctx));
+    thread::spawn(move || step2(&context));
     //wait for signal and pass it on
     receiver.recv_msg(0).unwrap();
     println!("Test successful!");

--- a/msrv-test/Cargo.toml
+++ b/msrv-test/Cargo.toml
@@ -1,0 +1,8 @@
+[package]
+name = "msrv-test"
+version = "0.0.1"
+authors = ["Andreas Rottmann <a.rottmann@gmx.at>"]
+edition = "2018"
+
+[dependencies]
+zmq = { path = ".." }

--- a/msrv-test/src/main.rs
+++ b/msrv-test/src/main.rs
@@ -1,0 +1,7 @@
+fn main() {
+    let ctx = zmq::Context::new();
+
+    let socket = ctx.socket(zmq::REQ).unwrap();
+    socket.connect("tcp://127.0.0.1:1234").unwrap();
+    socket.send("hello world!", 0).unwrap();
+}

--- a/src/message.rs
+++ b/src/message.rs
@@ -65,6 +65,14 @@ impl Message {
     /// function, its use is not recommended, and it will be removed in a future
     /// release. If there is a use-case that cannot be handled efficiently by
     /// the safe message constructors, please file an issue.
+    ///
+    /// # Safety
+    ///
+    /// The returned message contains uninitialized memory, and hence the
+    /// `Deref` and `DerefMut` traits must not be used until the memory has been
+    /// initialized. Since there is no proper API to do so, this function is
+    /// basically not usable safely, unless you happen to invoke C code that
+    /// takes a raw message pointer and initializes its contents.
     #[deprecated(
         since = "0.9.1",
         note = "This method has an unintuitive name, and should not be needed."

--- a/tests/compile-tests.rs
+++ b/tests/compile-tests.rs
@@ -1,4 +1,4 @@
-use std::env::var;
+use std::env;
 use std::path::PathBuf;
 
 fn run_mode(mode: &'static str) {
@@ -11,9 +11,8 @@ fn run_mode(mode: &'static str) {
         profile = env!("BUILD_PROFILE")
     ));
 
-    if let Ok(name) = var::<&str>("TESTNAME") {
-        let s: String = name.to_owned();
-        config.filter = Some(s)
+    if let Ok(name) = env::var("TESTNAME") {
+        config.filter = Some(name)
     }
     config.mode = cfg_mode;
     config.src_base = PathBuf::from(format!("tests/{}", mode));


### PR DESCRIPTION
There's some new tricks clippy learned, and more importantly building is broken on 1.32 due to some `dev-dependencies` requiring new language features. Since `dev-dependencies` should not affect downstream compilation, we should probably not do a full build on 1.32 anymore, but instead just ensure that the code still compiles.