### PR TITLE
Remove `std::error::Error` description method implementations

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1238,14 +1238,7 @@ impl fmt::Display for EncodeError {
     }
 }
 
-impl std::error::Error for EncodeError {
-    fn description(&self) -> &str {
-        match *self {
-            EncodeError::BadLength => "invalid data length",
-            EncodeError::FromUtf8Error(ref e) => e.description(),
-        }
-    }
-}
+impl std::error::Error for EncodeError {}
 
 /// Encode a binary key as Z85 printable text.
 ///
@@ -1297,14 +1290,7 @@ impl fmt::Display for DecodeError {
     }
 }
 
-impl std::error::Error for DecodeError {
-    fn description(&self) -> &str {
-        match *self {
-            DecodeError::BadLength => "invalid data length",
-            DecodeError::NulError(ref e) => e.description(),
-        }
-    }
-}
+impl std::error::Error for DecodeError {}
 
 /// Decode a binary key from Z85-encoded text.
 ///


### PR DESCRIPTION
The `description` method has been soft-deprecated for some time now,
and current nightly (1.41) warns upon its use:

    warning: use of deprecated item 'std::error::Error::description': use the Display impl or to_string()

Since our `description` implementation made use of the underlying
error's `description` method, we triggered that warning. Let's fix
that by just getting rid of the implementation containing the
offending code.