### PR TITLE
Provide inherent method to get error message string

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -299,10 +299,9 @@ impl Error {
             },
         }
     }
-}
 
-impl std::error::Error for Error {
-    fn description(&self) -> &str {
+    /// Returns the error message provided by 0MQ.
+    pub fn message(self) -> &'static str {
         unsafe {
             let s = zmq_sys::zmq_strerror(self.to_raw());
             let v: &'static [u8] = mem::transmute(ffi::CStr::from_ptr(s).to_bytes());
@@ -311,27 +310,22 @@ impl std::error::Error for Error {
     }
 }
 
+impl std::error::Error for Error {
+    fn description(&self) -> &str {
+        self.message()
+    }
+}
+
 impl std::fmt::Display for Error {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        unsafe {
-            let s = zmq_sys::zmq_strerror(self.to_raw());
-            let v: &'static [u8] = mem::transmute(ffi::CStr::from_ptr(s).to_bytes());
-            write!(f, "{}", str::from_utf8(v).unwrap())
-        }
+        write!(f, "{}", self.message())
     }
 }
 
 impl fmt::Debug for Error {
-    /// Return the error string for an error.
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        unsafe {
-            let s = zmq_sys::zmq_strerror(self.to_raw());
-            write!(
-                f,
-                "{}",
-                str::from_utf8(ffi::CStr::from_ptr(s).to_bytes()).unwrap()
-            )
-        }
+        // FIXME: An unquoted string is not a good `Debug` output.
+        write!(f, "{}", self.message())
     }
 }
 

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -159,8 +159,6 @@ test!(test_version, {
 });
 
 test!(test_zmq_error, {
-    use std::error::Error as StdError;
-
     let ctx = Context::new();
     let sock = ctx.socket(SocketType::REP).unwrap();
 
@@ -171,7 +169,7 @@ test!(test_zmq_error, {
     // ZMQ error strings might not be guaranteed, so we'll not check
     // against specific messages, but still check that formatting does
     // not segfault, for example, and gives the same strings.
-    let desc = err.description();
+    let desc = err.message();
     let display = format!("{}", err);
     let debug = format!("{:?}", err);
     assert_eq!(desc, display);


### PR DESCRIPTION
The new method provides an alternative to the `description` method on
`std::error::Error`, which is soft-deprecated, and current beta clippy
warns about its use.