### PR TITLE
Add `Context` getters and setters for `ZMQ_IO_THREADS`

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -428,6 +428,21 @@ impl Context {
         }
     }
 
+    /// Get the size of the ØMQ thread pool to handle I/O operations.
+    pub fn get_io_threads(&self) -> Result<i32> {
+        let rc =
+            zmq_try!(unsafe { zmq_sys::zmq_ctx_get(self.raw.ctx, zmq_sys::ZMQ_IO_THREADS as _) });
+        Ok(rc as i32)
+    }
+
+    /// Set the size of the ØMQ thread pool to handle I/O operations.
+    pub fn set_io_threads(&self, value: i32) -> Result<()> {
+        zmq_try!(unsafe {
+            zmq_sys::zmq_ctx_set(self.raw.ctx, zmq_sys::ZMQ_IO_THREADS as _, value as i32)
+        });
+        Ok(())
+    }
+
     /// Create a new socket.
     ///
     /// Note that the returned socket keeps a an `Arc` reference to

--- a/tests/context.rs
+++ b/tests/context.rs
@@ -1,0 +1,14 @@
+#[test]
+fn context_io_threads() {
+    let ctx = zmq::Context::new();
+
+    assert_eq!(ctx.get_io_threads().unwrap(), zmq_sys::ZMQ_IO_THREADS_DFLT as i32);
+
+    ctx.set_io_threads(0).unwrap();
+    assert_eq!(ctx.get_io_threads().unwrap(), 0);
+
+    ctx.set_io_threads(7).unwrap();
+    assert_eq!(ctx.get_io_threads().unwrap(), 7);
+
+    assert!(ctx.set_io_threads(-1).is_err());
+}


### PR DESCRIPTION
Fixes #206

Specific getters and setters are used following the precedence from `Socket`.