### PR TITLE
Fix errors with clippy 1.44.1

### DIFF
--- a/tests/message.rs
+++ b/tests/message.rs
@@ -29,7 +29,7 @@ quickcheck! {
     }
 
     fn msg_vec_roundtrip(input: Vec<u8>) -> bool {
-        let original = Message::from(&input.clone());
+        let original = Message::from(&input);
         Message::from(input) == original
     }
 }

--- a/zmq-sys/src/errno.rs
+++ b/zmq-sys/src/errno.rs
@@ -31,28 +31,28 @@ pub const ENETDOWN:         i32 = errno::ENETDOWN;
 pub const EADDRNOTAVAIL:    i32 = errno::EADDRNOTAVAIL;
 
 // native zmq error codes
-pub const EFSM:             i32 = (ZMQ_HAUSNUMERO + 51);
-pub const ENOCOMPATPROTO:   i32 = (ZMQ_HAUSNUMERO + 52);
-pub const ETERM:            i32 = (ZMQ_HAUSNUMERO + 53);
-pub const EMTHREAD:         i32 = (ZMQ_HAUSNUMERO + 54);
+pub const EFSM:             i32 = ZMQ_HAUSNUMERO + 51;
+pub const ENOCOMPATPROTO:   i32 = ZMQ_HAUSNUMERO + 52;
+pub const ETERM:            i32 = ZMQ_HAUSNUMERO + 53;
+pub const EMTHREAD:         i32 = ZMQ_HAUSNUMERO + 54;
 
 // These may be returned by libzmq if the target platform does not define these
 // errno codes.
-pub const ENOTSUP_ALT:         i32 = (ZMQ_HAUSNUMERO + 1);
-pub const EPROTONOSUPPORT_ALT: i32 = (ZMQ_HAUSNUMERO + 2);
-pub const ENOBUFS_ALT:         i32 = (ZMQ_HAUSNUMERO + 3);
-pub const ENETDOWN_ALT:        i32 = (ZMQ_HAUSNUMERO + 4);
-pub const EADDRINUSE_ALT:      i32 = (ZMQ_HAUSNUMERO + 5);
-pub const EADDRNOTAVAIL_ALT:   i32 = (ZMQ_HAUSNUMERO + 6);
-pub const ECONNREFUSED_ALT:    i32 = (ZMQ_HAUSNUMERO + 7);
-pub const EINPROGRESS_ALT:     i32 = (ZMQ_HAUSNUMERO + 8);
-pub const ENOTSOCK_ALT:        i32 = (ZMQ_HAUSNUMERO + 9);
-pub const EMSGSIZE_ALT:        i32 = (ZMQ_HAUSNUMERO + 10);
-pub const EAFNOSUPPORT_ALT:    i32 = (ZMQ_HAUSNUMERO + 11);
-pub const ENETUNREACH_ALT:     i32 = (ZMQ_HAUSNUMERO + 12);
-pub const ECONNABORTED_ALT:    i32 = (ZMQ_HAUSNUMERO + 13);
-pub const ECONNRESET_ALT:      i32 = (ZMQ_HAUSNUMERO + 14);
-pub const ENOTCONN_ALT:        i32 = (ZMQ_HAUSNUMERO + 15);
-pub const ETIMEDOUT_ALT:       i32 = (ZMQ_HAUSNUMERO + 16);
-pub const EHOSTUNREACH_ALT:    i32 = (ZMQ_HAUSNUMERO + 17);
-pub const ENETRESET_ALT:       i32 = (ZMQ_HAUSNUMERO + 18);
+pub const ENOTSUP_ALT:         i32 = ZMQ_HAUSNUMERO + 1;
+pub const EPROTONOSUPPORT_ALT: i32 = ZMQ_HAUSNUMERO + 2;
+pub const ENOBUFS_ALT:         i32 = ZMQ_HAUSNUMERO + 3;
+pub const ENETDOWN_ALT:        i32 = ZMQ_HAUSNUMERO + 4;
+pub const EADDRINUSE_ALT:      i32 = ZMQ_HAUSNUMERO + 5;
+pub const EADDRNOTAVAIL_ALT:   i32 = ZMQ_HAUSNUMERO + 6;
+pub const ECONNREFUSED_ALT:    i32 = ZMQ_HAUSNUMERO + 7;
+pub const EINPROGRESS_ALT:     i32 = ZMQ_HAUSNUMERO + 8;
+pub const ENOTSOCK_ALT:        i32 = ZMQ_HAUSNUMERO + 9;
+pub const EMSGSIZE_ALT:        i32 = ZMQ_HAUSNUMERO + 10;
+pub const EAFNOSUPPORT_ALT:    i32 = ZMQ_HAUSNUMERO + 11;
+pub const ENETUNREACH_ALT:     i32 = ZMQ_HAUSNUMERO + 12;
+pub const ECONNABORTED_ALT:    i32 = ZMQ_HAUSNUMERO + 13;
+pub const ECONNRESET_ALT:      i32 = ZMQ_HAUSNUMERO + 14;
+pub const ENOTCONN_ALT:        i32 = ZMQ_HAUSNUMERO + 15;
+pub const ETIMEDOUT_ALT:       i32 = ZMQ_HAUSNUMERO + 16;
+pub const EHOSTUNREACH_ALT:    i32 = ZMQ_HAUSNUMERO + 17;
+pub const ENETRESET_ALT:       i32 = ZMQ_HAUSNUMERO + 18;


### PR DESCRIPTION
Fix `error: redundant clone`
Fix `error: unnecessary parentheses around assigned value`