### PR TITLE
Switch from compiletest_rs to trybuild

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,19 +28,19 @@ zmq_has = []
 vendored = ['zmq-sys/vendored']
 
 [dependencies]
+bitflags = "1.0"
 libc = "0.2.15"
 zmq-sys = { version = "0.11.0", path = "zmq-sys" }
-bitflags = "1.0"
 
 [dev-dependencies]
-log = "0.4.3"
+trybuild = "*" # { version = "0.4.0", features = ["stable"] }
 env_logger = { version = "0.7", default-features = false }
+log = "0.4.3"
+nix = "0.16"
 quickcheck = "0.9"
 rand = "0.7"
 tempfile = "3"
 timebomb = "0.1.2"
-nix = "0.16"
-compiletest_rs = { version = "0.4.0", features = ["stable"] }
 
 [[example]]
 name = "helloworld_client"

--- a/tests/compile-fail/no-leaking-poll-items.rs
+++ b/tests/compile-fail/no-leaking-poll-items.rs
@@ -1,5 +1,3 @@
-extern crate zmq;
-
 fn main() {
     let context = zmq::Context::new();
     let _poll_item = {

--- a/tests/compile-fail/no-leaking-poll-items.stderr
+++ b/tests/compile-fail/no-leaking-poll-items.stderr
@@ -1,0 +1,10 @@
+error[E0597]: `socket` does not live long enough
+ --> $DIR/no-leaking-poll-items.rs:5:9
+  |
+3 |     let _poll_item = {
+  |         ---------- borrow later stored here
+4 |         let socket = context.socket(zmq::PAIR).unwrap();
+5 |         socket.as_poll_item(zmq::POLLIN)
+  |         ^^^^^^ borrowed value does not live long enough
+6 |     }; //~^ ERROR `socket` does not live long enough [E0597]
+  |     - `socket` dropped here while still borrowed

--- a/tests/compile-fail/socket-thread-unsafe.rs
+++ b/tests/compile-fail/socket-thread-unsafe.rs
@@ -1,5 +1,3 @@
-extern crate zmq;
-
 use std::thread;
 
 macro_rules! t {
@@ -12,7 +10,7 @@ fn main() {
     let mut context = zmq::Context::new();
     let socket = t!(context.socket(zmq::REP));
     let s = &socket;
-    let t = thread::spawn(move || {  //~ cannot be shared between threads safely [E0277]
+    let t = thread::spawn(move || {
         t!(s.bind("tcp://127.0.0.1:12345"))
     });
     socket.send("ABC", 0);

--- a/tests/compile-fail/socket-thread-unsafe.stderr
+++ b/tests/compile-fail/socket-thread-unsafe.stderr
@@ -1,0 +1,10 @@
+error[E0277]: `*mut std::ffi::c_void` cannot be shared between threads safely
+   --> $DIR/socket-thread-unsafe.rs:13:13
+    |
+13  |     let t = thread::spawn(move || {
+    |             ^^^^^^^^^^^^^ `*mut std::ffi::c_void` cannot be shared between threads safely
+    |
+    = help: within `zmq::Socket`, the trait `std::marker::Sync` is not implemented for `*mut std::ffi::c_void`
+    = note: required because it appears within the type `zmq::Socket`
+    = note: required because of the requirements on the impl of `std::marker::Send` for `&zmq::Socket`
+    = note: required because it appears within the type `[closure@$DIR/tests/compile-fail/socket-thread-unsafe.rs:13:27: 15:6 s:&zmq::Socket]`

--- a/tests/compile-tests.rs
+++ b/tests/compile-tests.rs
@@ -1,26 +1,5 @@
-use std::env;
-use std::path::PathBuf;
-
-fn run_mode(mode: &'static str) {
-    let mut config = compiletest_rs::Config::default();
-
-    let cfg_mode = mode.parse().expect("Invalid mode");
-
-    config.target_rustcflags = Some(format!(
-        "-L target/{profile} -L target/{profile}/deps",
-        profile = env!("BUILD_PROFILE")
-    ));
-
-    if let Ok(name) = env::var("TESTNAME") {
-        config.filter = Some(name)
-    }
-    config.mode = cfg_mode;
-    config.src_base = PathBuf::from(format!("tests/{}", mode));
-
-    compiletest_rs::run_tests(&config);
-}
-
 #[test]
-fn compile_test() {
-    run_mode("compile-fail");
+fn compile_fail() {
+    let t = trybuild::TestCases::new();
+    t.compile_fail("tests/compile-fail/*.rs");
 }


### PR DESCRIPTION
trybuild is a bit more of a robust test suite, which uses cargo instead of rustc to drive the build.