### PR TITLE
zmq_use_fd option

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -877,6 +877,7 @@ impl Socket {
         (get_heartbeat_ttl, set_heartbeat_ttl) => ZMQ_HEARTBEAT_TTL as i32,
         (get_heartbeat_timeout, set_heartbeat_timeout) => ZMQ_HEARTBEAT_TIMEOUT as i32,
         (get_connect_timeout, set_connect_timeout) => ZMQ_CONNECT_TIMEOUT as i32,
+        (get_use_fd, set_use_fd) => ZMQ_USE_FD as RawFd,
     }
 
     // TODO: deprecate to align with ZMQ's preferred naming


### PR DESCRIPTION
Add support for `ZMQ_USE_FD` socket option.