### PR TITLE
Prepare release v0.9.3

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zmq"
-version = "0.9.2"
+version = "0.9.3"
 authors = [
     "a.rottmann@gmx.at",
     "erick.tryzelaar@gmail.com",

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,16 @@
+# 0.9.3
+
+## New and improved functionality
+
+- Support for the `ZMQ_IO_THREADS` context options, implemented in #311
+- Implemented `AsRawFd` trait for sockets in #306
+- Added socket unbinding in #300
+- Added support for `PollItem` associated socket checking in #292
+
+## Fixes
+
+- Fixed broken `Message::from(Box<[u8]>)` in 2b9bb43; see #301
+
 # 0.9.2
 
 ## New and improved functionality


### PR DESCRIPTION
Hi! Thanks for the library!

Do you mind releasing `0.9.3` version and publishing it to crates.io? It seems there have been a few things added/fixed that haven't been published.

I want to use the new `ZMQ_IO_THREADS` options, but it seems I can't update by simply sticking `git` version into my `Cargo.toml`. Another library I'm using has `zmq = ">=0.9.2"` as a dependency and If I use a non-crates.io version, `cargo` tries to build two different `zmq`s, which is causing linking issues with `zmq-sys`. I think publishing `0.9.3` should solve this.