### PR TITLE
Move to zeromq-src 0.2

### DIFF
--- a/zmq-sys/Cargo.toml
+++ b/zmq-sys/Cargo.toml
@@ -14,15 +14,16 @@ build = "build/main.rs"
 links = "zmq"
 
 [features]
-# Build libzmq from source.
-vendored = ['zeromq-src']
+# Build libzmq from source with encryption support via libsodium.
+vendored = ['zeromq-src', 'libsodium-sys-stable']
 
 [dependencies]
 libc = "0.2.15"
+libsodium-sys-stable = { version = "1.0", optional = true }
 
 [build-dependencies]
 metadeps = "1"
-zeromq-src = { version = "0.1.7", optional = true }
+zeromq-src = { version = "0.2.0", optional = true }
 
 [package.metadata.pkg-config]
 libzmq = "4.1"

--- a/zmq-sys/build/vendored.rs
+++ b/zmq-sys/build/vendored.rs
@@ -4,8 +4,17 @@ pub fn configure() {
     println!("cargo:rerun-if-changed=build/main.rs");
     println!("cargo:rerun-if-env-changed=PROFILE");
 
-    let wants_debug = env::var("PROFILE").unwrap() == "debug";
+    let lib_dir = env::var("DEP_SODIUM_LIB").expect("build metadata `DEP_SODIUM_LIB` required");
+    let include_dir =
+        env::var("DEP_SODIUM_INCLUDE").expect("build metadata `DEP_SODIUM_INCLUDE` required");
 
-    let artifacts = zeromq_src::Build::new().link_static(true).build_debug(wants_debug).build();
-    artifacts.print_cargo_metadata();
+    let location = zeromq_src::LibLocation::new(lib_dir, include_dir);
+
+    // Note that by default `libzmq` builds without `libsodium` by instead
+    // relying on `tweetnacl`. However since this `tweetnacl` [has never been
+    // audited nor is ready for production](https://github.com/zeromq/libzmq/issues/3006),
+    // we link against `libsodium` to enable `ZMQ_CURVE`.
+    zeromq_src::Build::new()
+        .with_libsodium(Some(location))
+        .build();
 }


### PR DESCRIPTION
* Update to zeromq-src with bumps libzmq version to 4.3.4 and
    enables building without cmake.
* Link against libsodium for encryption support for security
    and performance reasons.

Note that im unsure whether libsodium should be linked by default since I'm assuming not all users use CURVE.