### PR TITLE
zmq-sys: Replace `metadeps` with `system-deps` successor

### DIFF
--- a/zmq-sys/Cargo.toml
+++ b/zmq-sys/Cargo.toml
@@ -21,8 +21,8 @@ vendored = ['zeromq-src']
 libc = "0.2.15"
 
 [build-dependencies]
-metadeps = "1"
+system-deps = "6"
 zeromq-src = { version = "0.1.7", optional = true }
 
-[package.metadata.pkg-config]
+[package.metadata.system-deps]
 libzmq = "4.1"

--- a/zmq-sys/build/pkg_config.rs
+++ b/zmq-sys/build/pkg_config.rs
@@ -22,9 +22,7 @@ pub fn configure() {
         (Some(_), None) => panic!("Unable to locate libzmq include directory."),
         (None, Some(_)) => panic!("Unable to locate libzmq library directory."),
         (None, None) => {
-            if let Err(e) = metadeps::probe() {
-                panic!("Unable to locate libzmq:\n{}", e);
-            }
+            system_deps::Config::new().probe().unwrap();
         }
     }
 }


### PR DESCRIPTION
`metadeps` hasn't seen an update and crate release for 4-5 years, with `system-deps` being a fork and actively maintained successor to it.
