### PR TITLE
Make Socket Send and Sync

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -490,6 +490,8 @@ pub struct Socket {
 }
 
 unsafe impl Send for Socket {}
+unsafe impl Sync for Socket {}
+
 
 impl Drop for Socket {
     fn drop(&mut self) {


### PR DESCRIPTION
Without this change, trying to access a Socket in a global / static variable does not work even if a single thread is actually accessing the socket.

error[E0277]: `*mut c_void` cannot be shared between threads safely
  --> src/lib.rs:49:30
   |
49 |         let nettle_globals = globals::get::<NettleGlobals>();
   |                              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `*mut c_void` cannot be shared between threads safely
   |
   = help: within `(NettleHandle, NettleOperator)`, the trait `Sync` is not implemented for `*mut c_void`
   = note: required because it appears within the type `Socket`
note: required because it appears within the type `NettleOperator`
  --> src/lib.rs:23:8
  