### PR TITLE
expose ZMQ_INVERT_MATCHING sockopt

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -793,6 +793,7 @@ impl Socket {
         (is_gssapi_plaintext, set_gssapi_plaintext) => ZMQ_GSSAPI_PLAINTEXT as bool,
         (_, set_req_relaxed) => ZMQ_REQ_RELAXED as bool,
         (_, set_req_correlate) => ZMQ_REQ_CORRELATE as bool,
+        (is_invert_matching, set_invert_matching) => ZMQ_INVERT_MATCHING as bool,
     }
 
     /// Return the type of this socket.

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -586,6 +586,16 @@ test!(test_getset_connect_timeout, {
     }
 });
 
+test!(test_getset_inverted_matching, {
+    let ctx = Context::new();
+    let sock = ctx.socket(PUB).unwrap();
+    assert!(!sock.is_invert_matching().unwrap());
+    sock.set_invert_matching(true).unwrap();
+    assert!(sock.is_invert_matching().unwrap());
+    sock.set_invert_matching(false).unwrap();
+    assert!(!sock.is_invert_matching().unwrap());
+});
+
 #[cfg(feature = "compiletest_rs")]
 mod compile {
     extern crate compiletest_rs as compiletest;


### PR DESCRIPTION
This exposes the ability to get and set the `ZMQ_INVERT_MATCHING` socket option.