### PR TITLE
Upgrade `zeromq-src` to `0.3`

### DIFF
--- a/zmq-sys/Cargo.toml
+++ b/zmq-sys/Cargo.toml
@@ -20,7 +20,7 @@ libc = "0.2.15"
 
 [build-dependencies]
 system-deps = "6"
-zeromq-src = { version = "0.2.1" }
+zeromq-src = "0.3"
 
 [package.metadata.system-deps]
 libzmq = "4.1"


### PR DESCRIPTION
This release includes a fix for cross-compiling, and bumps the ZeroMQ source to v4.3.5.
