### PR TITLE
upgrade to 2021 edition from 2018

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ categories = ["api-bindings", "network-programming"]
 repository = "https://github.com/erickt/rust-zmq"
 readme = "README.md"
 build = "build.rs"
-edition = "2018"
+edition = "2021"
 
 [badges]
 maintenance = { status = "actively-maintained" }

--- a/tests/compile-fail/no-leaking-poll-items.stderr
+++ b/tests/compile-fail/no-leaking-poll-items.stderr
@@ -4,7 +4,8 @@ error[E0597]: `socket` does not live long enough
 3 |     let _poll_item = {
   |         ---------- borrow later stored here
 4 |         let socket = context.socket(zmq::PAIR).unwrap();
+  |             ------ binding `socket` declared here
 5 |         socket.as_poll_item(zmq::POLLIN)
-  |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ borrowed value does not live long enough
+  |         ^^^^^^ borrowed value does not live long enough
 6 |     }; //~^ ERROR `socket` does not live long enough [E0597]
   |     - `socket` dropped here while still borrowed

--- a/tests/compile-fail/socket-thread-unsafe.stderr
+++ b/tests/compile-fail/socket-thread-unsafe.stderr
@@ -1,18 +1,31 @@
 error[E0277]: `*mut c_void` cannot be shared between threads safely
-  --> tests/compile-fail/socket-thread-unsafe.rs:13:13
-   |
-13 |     let t = thread::spawn(move || {
-   |             ^^^^^^^^^^^^^ `*mut c_void` cannot be shared between threads safely
-   |
-   = help: within `Socket`, the trait `Sync` is not implemented for `*mut c_void`
-   = note: required because it appears within the type `Socket`
-   = note: required because of the requirements on the impl of `Send` for `&Socket`
-note: required because it's used within this closure
   --> tests/compile-fail/socket-thread-unsafe.rs:13:27
    |
 13 |       let t = thread::spawn(move || {
-   |  ___________________________^
+   |  _____________-------------_^
+   | |             |
+   | |             required by a bound introduced by this call
 14 | |         t!(s.bind("tcp://127.0.0.1:12345"))
 15 | |     });
-   | |_____^
+   | |_____^ `*mut c_void` cannot be shared between threads safely
+   |
+   = help: within `Socket`, the trait `Sync` is not implemented for `*mut c_void`, which is required by `{closure@$DIR/tests/compile-fail/socket-thread-unsafe.rs:13:27: 13:34}: Send`
+note: required because it appears within the type `Socket`
+  --> src/lib.rs
+   |
+   | pub struct Socket {
+   |            ^^^^^^
+   = note: required for `&Socket` to implement `Send`
+note: required because it's used within this closure
+  --> tests/compile-fail/socket-thread-unsafe.rs:13:27
+   |
+13 |     let t = thread::spawn(move || {
+   |                           ^^^^^^^
 note: required by a bound in `spawn`
+  --> $RUST/std/src/thread/mod.rs
+   |
+   | pub fn spawn<F, T>(f: F) -> JoinHandle<T>
+   |        ----- required by a bound in this function
+...
+   |     F: Send + 'static,
+   |        ^^^^ required by this bound in `spawn`

--- a/tests/z85.rs
+++ b/tests/z85.rs
@@ -33,12 +33,12 @@ fn test_decode_errors() {
     }
 }
 
+/*
 // Valid input for z85 encoding (i.e. a slice of bytes with its length
 // being a multiple of 4)
 #[derive(Clone, Debug)]
 struct Input(Vec<u8>);
 
-/*
 // Disabled because quickcheck doesn't expose gen_range and gen anymore
 
 impl Arbitrary for Input {


### PR DESCRIPTION
`cargo fix --edition` was run, but produced no changes. 
then the edition values was changed from 2018 to 2021. 2024 is in development. 
`cargo test` revealed two tests of compiler errors needed to change their expected compiler error messages. These have been updated to do so. 
`cargo fix` revealed an unused Input struct in z85. it's been moved in to the commented out code which uses it. all remaining warnings are now in zeromq-src