### PR TITLE
Adds support for creating a Context from a non-owned pointer

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,16 +19,17 @@ edition = "2018"
 maintenance = { status = "actively-maintained" }
 
 [features]
-default = ["zmq_has"]
+default = ["zmq_has", "static"]
 # zmq_has was added in zeromq 4.1. As we now require 4.1 or newer,
 # this feature is a no-op and only present for backward-compatibility;
 # it will be removed in the next API-breaking release.
 zmq_has = []
+static = ["zmq-sys/static"]
 
 [dependencies]
 bitflags = "1.0"
 libc = "0.2.15"
-zmq-sys = { version = "0.12.0", path = "zmq-sys" }
+zmq-sys = { version = "0.12.0", path = "zmq-sys", default-features = false }
 
 [dev-dependencies]
 trybuild = { version = "1" }

--- a/zmq-sys/Cargo.toml
+++ b/zmq-sys/Cargo.toml
@@ -14,13 +14,15 @@ build = "build/main.rs"
 links = "zmq"
 
 [features]
+default = ["static"]
+static = ["dep:zeromq-src"]
 
 [dependencies]
 libc = "0.2.15"
 
 [build-dependencies]
 system-deps = "6"
-zeromq-src = { version = "0.2.1" }
+zeromq-src = { version = "0.2.1", optional = true }
 
 [package.metadata.system-deps]
 libzmq = "4.1"

--- a/zmq-sys/build/main.rs
+++ b/zmq-sys/build/main.rs
@@ -1,3 +1,4 @@
+#[cfg(feature = "static")]
 pub fn configure() {
     println!("cargo:rerun-if-changed=build/main.rs");
     println!("cargo:rerun-if-env-changed=PROFILE");
@@ -12,5 +13,6 @@ pub fn configure() {
 }
 
 fn main() {
+    #[cfg(feature = "static")]
     configure()
 }


### PR DESCRIPTION
Similar to #316, I'm writing Rust code that communicates with a thread running C code. Further, I have a need to build without statically linking libzmq. To avoid breaking changes, I've left static linking the default behavior. Thanks!