### PR TITLE
Code quality fixes including fix for undefined behavior in Message::with_size and <Message as From<&[u8]>>::from

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1291,7 +1291,7 @@ pub fn z85_encode(data: &[u8]) -> result::Result<String, EncodeError> {
         return Err(EncodeError::BadLength);
     }
 
-    let len = data.len() * 5 / 4 + 1;
+    let len = data.len() / 4 * 5 + 1;
     let mut dest = vec![0u8; len];
 
     unsafe {
@@ -1350,7 +1350,7 @@ pub fn z85_decode(data: &str) -> result::Result<Vec<u8>, DecodeError> {
         return Err(DecodeError::BadLength);
     }
 
-    let len = data.len() * 4 / 5;
+    let len = data.len() / 5 * 4;
     let mut dest = vec![0u8; len];
 
     let c_str = ffi::CString::new(data)?;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1271,7 +1271,14 @@ impl fmt::Display for EncodeError {
     }
 }
 
-impl std::error::Error for EncodeError {}
+impl std::error::Error for EncodeError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match self {
+            Self::BadLength => None,
+            Self::FromUtf8Error(err) => Some(err),
+        }
+    }
+}
 
 /// Encode a binary key as Z85 printable text.
 ///
@@ -1323,7 +1330,14 @@ impl fmt::Display for DecodeError {
     }
 }
 
-impl std::error::Error for DecodeError {}
+impl std::error::Error for DecodeError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match self {
+            Self::BadLength => None,
+            Self::NulError(err) => Some(err),
+        }
+    }
+}
 
 /// Decode a binary key from Z85-encoded text.
 ///

--- a/src/message.rs
+++ b/src/message.rs
@@ -1,7 +1,9 @@
 use libc::size_t;
 
+use std::cmp::Ordering;
 use std::ffi;
 use std::fmt;
+use std::hash::{Hash, Hasher};
 use std::ops::{Deref, DerefMut};
 use std::os::raw::c_void;
 use std::{ptr, slice, str};
@@ -157,6 +159,44 @@ impl Message {
     }
 }
 
+impl PartialEq for Message {
+    fn eq(&self, other: &Message) -> bool {
+        self[..] == other[..]
+    }
+}
+
+impl Eq for Message {}
+
+impl PartialOrd for Message {
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+impl Ord for Message {
+    fn cmp(&self, other: &Self) -> Ordering {
+        self[..].cmp(&other[..])
+    }
+}
+
+impl Clone for Message {
+    fn clone(&self) -> Self {
+        self[..].into()
+    }
+}
+
+impl Default for Message {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl Hash for Message {
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        self[..].hash(state);
+    }
+}
+
 impl Deref for Message {
     type Target = [u8];
 
@@ -171,14 +211,6 @@ impl Deref for Message {
         }
     }
 }
-
-impl PartialEq for Message {
-    fn eq(&self, other: &Message) -> bool {
-        self[..] == other[..]
-    }
-}
-
-impl Eq for Message {}
 
 impl DerefMut for Message {
     fn deref_mut(&mut self) -> &mut [u8] {

--- a/src/message.rs
+++ b/src/message.rs
@@ -152,7 +152,7 @@ impl Message {
         if value.is_null() {
             None
         } else {
-            str::from_utf8(unsafe { ffi::CStr::from_ptr(value) }.to_bytes()).ok()
+            unsafe { ffi::CStr::from_ptr(value) }.to_str().ok()
         }
     }
 }

--- a/src/sockopt.rs
+++ b/src/sockopt.rs
@@ -2,7 +2,7 @@ use libc::{c_int, c_uint, size_t};
 use std::os::raw::c_void;
 use std::result;
 use std::string::FromUtf8Error;
-use std::{mem, ptr, str};
+use std::{mem, ptr};
 
 use super::{PollEvents, Result};
 
@@ -47,8 +47,7 @@ getsockopt_num!(c_uint, u32);
 getsockopt_num!(i64, i64);
 getsockopt_num!(u64, u64);
 
-pub fn get_bytes(sock: *mut c_void, opt: c_int, size: size_t) -> Result<Vec<u8>> {
-    let mut size = size;
+pub fn get_bytes(sock: *mut c_void, opt: c_int, mut size: size_t) -> Result<Vec<u8>> {
     let mut value = vec![0u8; size];
 
     zmq_try!(unsafe {

--- a/tests/message_from_boxed_slice.rs
+++ b/tests/message_from_boxed_slice.rs
@@ -26,7 +26,7 @@ static A: Allocator = Allocator;
 #[test]
 fn message_from_boxed_slice() {
     let mut b: Box<[u8]> = Box::new([0u8; 42]);
-    CHECK_PTR.store(b.as_mut_ptr() as *mut u8, Ordering::SeqCst);
+    CHECK_PTR.store(b.as_mut_ptr(), Ordering::SeqCst);
     let _ = zmq::Message::from(b);
     assert_eq!(CHECK_PTR.load(Ordering::SeqCst), ptr::null_mut());
 }

--- a/tests/monitor.rs
+++ b/tests/monitor.rs
@@ -2,7 +2,6 @@
 mod common;
 
 use std::str;
-use std::u16;
 
 fn version_ge_4_3() -> bool {
     let (major, minor, _) = zmq::version();

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -71,7 +71,7 @@ test!(test_exchanging_multipart, {
     let (sender, receiver) = create_socketpair();
 
     // convenience API
-    sender.send_multipart(&["foo", "bar"], 0).unwrap();
+    sender.send_multipart(["foo", "bar"], 0).unwrap();
     assert_eq!(receiver.recv_multipart(0).unwrap(), vec![b"foo", b"bar"]);
 
     // manually

--- a/tests/unix/connection.rs
+++ b/tests/unix/connection.rs
@@ -103,7 +103,7 @@ fn poll_worker(_ctx: &zmq::Context, socket: &zmq::Socket) {
             }
             Some(msg) => {
                 state.wait(zmq::POLLOUT);
-                let done = msg.len() == 0;
+                let done = msg.is_empty();
                 socket.send(msg, zmq::DONTWAIT).unwrap();
                 if done {
                     break;

--- a/tests/z85.rs
+++ b/tests/z85.rs
@@ -33,13 +33,13 @@ fn test_decode_errors() {
     }
 }
 
+/*
+// Disabled because quickcheck doesn't expose gen_range and gen anymore
+
 // Valid input for z85 encoding (i.e. a slice of bytes with its length
 // being a multiple of 4)
 #[derive(Clone, Debug)]
 struct Input(Vec<u8>);
-
-/*
-// Disabled because quickcheck doesn't expose gen_range and gen anymore
 
 impl Arbitrary for Input {
     fn arbitrary(g: &mut Gen) -> Self {


### PR DESCRIPTION
See commit messages for detailed explanations.

`Message::with_size` and `<Message as From<&[u8]>>::from` call `msg.as_mut_ptr()` on a `msg` that contains uninitialized bytes, `as_mut_ptr` did not exist on Message, so the one of `&mut [u8]` was used, through `DerefMut`. This created a `&mut [u8]` to uninitialized data.