### PR TITLE
Fix clippy lints since Rust 1.83

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -8,48 +8,28 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
-        rust: [stable]
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v2
-      - uses: actions-rs/toolchain@v1
-        with:
-          toolchain: ${{ matrix.rust }}
-          override: true
       - name: Cargo build
-        uses: actions-rs/cargo@v1
-        with:
-          command: build
-          args: --workspace --all-targets
+        run: cargo build --workspace --all-targets
   test:
     name: Test
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
-        rust: [stable]
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v2
-      - uses: actions-rs/toolchain@v1
-        with:
-          toolchain: ${{ matrix.rust }}
-          override: true
       - name: Cargo test
-        uses: actions-rs/cargo@v1
-        with:
-          command: test
-          args: --workspace --all-targets
+        run: cargo test --workspace --all-targets
   lint:
     name: Lint
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
-        rust: [stable]
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v2
       - name: Cargo clippy
-        uses: actions-rs/cargo@v1
-        with:
-          command: clippy
-          args: --workspace --all-targets -- -D warnings
+        run: cargo clippy --workspace --all-targets -- -D warnings

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -371,7 +371,7 @@ pub fn version() -> (i32, i32, i32) {
         zmq_sys::zmq_version(&mut major, &mut minor, &mut patch);
     }
 
-    (major as i32, minor as i32, patch as i32)
+    (major, minor, patch)
 }
 
 struct RawContext {
@@ -442,7 +442,7 @@ impl Context {
     /// Set the size of the ØMQ thread pool to handle I/O operations.
     pub fn set_io_threads(&self, value: i32) -> Result<()> {
         zmq_try!(unsafe {
-            zmq_sys::zmq_ctx_set(self.raw.ctx, zmq_sys::ZMQ_IO_THREADS as _, value as i32)
+            zmq_sys::zmq_ctx_set(self.raw.ctx, zmq_sys::ZMQ_IO_THREADS as _, value)
         });
         Ok(())
     }

--- a/src/message.rs
+++ b/src/message.rs
@@ -232,14 +232,14 @@ impl From<Box<[u8]>> for Message {
     }
 }
 
-impl<'a> From<&'a str> for Message {
+impl From<&str> for Message {
     /// Construct a message from a string slice by copying the UTF-8 data.
     fn from(msg: &str) -> Self {
         Message::from(msg.as_bytes())
     }
 }
 
-impl<'a> From<&'a String> for Message {
+impl From<&String> for Message {
     /// Construct a message from a string slice by copying the UTF-8 data.
     fn from(msg: &String) -> Self {
         Message::from(msg.as_bytes())

--- a/src/sockopt.rs
+++ b/src/sockopt.rs
@@ -101,13 +101,13 @@ fn setsockopt_null(sock: *mut c_void, opt: c_int) -> Result<()> {
     Ok(())
 }
 
-impl<'a> Setter for &'a str {
+impl Setter for &str {
     fn set(sock: *mut c_void, opt: c_int, value: Self) -> Result<()> {
         set(sock, opt, value.as_bytes())
     }
 }
 
-impl<'a> Setter for Option<&'a str> {
+impl Setter for Option<&str> {
     fn set(sock: *mut c_void, opt: c_int, value: Self) -> Result<()> {
         if let Some(s) = value {
             set(sock, opt, s.as_bytes())

--- a/tests/compile-fail/no-leaking-poll-items.stderr
+++ b/tests/compile-fail/no-leaking-poll-items.stderr
@@ -4,7 +4,8 @@ error[E0597]: `socket` does not live long enough
 3 |     let _poll_item = {
   |         ---------- borrow later stored here
 4 |         let socket = context.socket(zmq::PAIR).unwrap();
+  |             ------ binding `socket` declared here
 5 |         socket.as_poll_item(zmq::POLLIN)
-  |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ borrowed value does not live long enough
+  |         ^^^^^^ borrowed value does not live long enough
 6 |     }; //~^ ERROR `socket` does not live long enough [E0597]
   |     - `socket` dropped here while still borrowed

--- a/tests/compile-fail/socket-thread-unsafe.stderr
+++ b/tests/compile-fail/socket-thread-unsafe.stderr
@@ -1,18 +1,31 @@
 error[E0277]: `*mut c_void` cannot be shared between threads safely
-  --> tests/compile-fail/socket-thread-unsafe.rs:13:13
-   |
-13 |     let t = thread::spawn(move || {
-   |             ^^^^^^^^^^^^^ `*mut c_void` cannot be shared between threads safely
-   |
-   = help: within `Socket`, the trait `Sync` is not implemented for `*mut c_void`
-   = note: required because it appears within the type `Socket`
-   = note: required because of the requirements on the impl of `Send` for `&Socket`
-note: required because it's used within this closure
   --> tests/compile-fail/socket-thread-unsafe.rs:13:27
    |
 13 |       let t = thread::spawn(move || {
-   |  ___________________________^
+   |  _____________-------------_^
+   | |             |
+   | |             required by a bound introduced by this call
 14 | |         t!(s.bind("tcp://127.0.0.1:12345"))
 15 | |     });
-   | |_____^
+   | |_____^ `*mut c_void` cannot be shared between threads safely
+   |
+   = help: within `Socket`, the trait `Sync` is not implemented for `*mut c_void`, which is required by `{closure@$DIR/tests/compile-fail/socket-thread-unsafe.rs:13:27: 13:34}: Send`
+note: required because it appears within the type `Socket`
+  --> src/lib.rs
+   |
+   | pub struct Socket {
+   |            ^^^^^^
+   = note: required for `&Socket` to implement `Send`
+note: required because it's used within this closure
+  --> tests/compile-fail/socket-thread-unsafe.rs:13:27
+   |
+13 |     let t = thread::spawn(move || {
+   |                           ^^^^^^^
 note: required by a bound in `spawn`
+  --> $RUST/std/src/thread/mod.rs
+   |
+   | pub fn spawn<F, T>(f: F) -> JoinHandle<T>
+   |        ----- required by a bound in this function
+...
+   |     F: Send + 'static,
+   |        ^^^^ required by this bound in `spawn`

--- a/tests/compile-fail/socket-thread-unsafe.stderr
+++ b/tests/compile-fail/socket-thread-unsafe.stderr
@@ -23,9 +23,3 @@ note: required because it's used within this closure
    |                           ^^^^^^^
 note: required by a bound in `spawn`
   --> $RUST/std/src/thread/mod.rs
-   |
-   | pub fn spawn<F, T>(f: F) -> JoinHandle<T>
-   |        ----- required by a bound in this function
-...
-   |     F: Send + 'static,
-   |        ^^^^ required by this bound in `spawn`

--- a/tests/message_from_boxed_slice.rs
+++ b/tests/message_from_boxed_slice.rs
@@ -26,7 +26,7 @@ static A: Allocator = Allocator;
 #[test]
 fn message_from_boxed_slice() {
     let mut b: Box<[u8]> = Box::new([0u8; 42]);
-    CHECK_PTR.store(b.as_mut_ptr() as *mut u8, Ordering::SeqCst);
+    CHECK_PTR.store(b.as_mut_ptr(), Ordering::SeqCst);
     let _ = zmq::Message::from(b);
     assert_eq!(CHECK_PTR.load(Ordering::SeqCst), ptr::null_mut());
 }

--- a/tests/monitor.rs
+++ b/tests/monitor.rs
@@ -2,7 +2,6 @@
 mod common;
 
 use std::str;
-use std::u16;
 
 fn version_ge_4_3() -> bool {
     let (major, minor, _) = zmq::version();

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -71,7 +71,7 @@ test!(test_exchanging_multipart, {
     let (sender, receiver) = create_socketpair();
 
     // convenience API
-    sender.send_multipart(&["foo", "bar"], 0).unwrap();
+    sender.send_multipart(["foo", "bar"], 0).unwrap();
     assert_eq!(receiver.recv_multipart(0).unwrap(), vec![b"foo", b"bar"]);
 
     // manually

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -585,26 +585,3 @@ test!(test_getset_connect_timeout, {
         assert_eq!(sock.get_connect_timeout().unwrap(), 5000);
     }
 });
-
-#[cfg(feature = "compiletest_rs")]
-mod compile {
-    extern crate compiletest_rs as compiletest;
-
-    use std::path::PathBuf;
-
-    fn run_mode(mode: &'static str) {
-        let mut config = compiletest::Config::default();
-        let cfg_mode = mode.parse().expect("Invalid mode");
-
-        config.mode = cfg_mode;
-        config.src_base = PathBuf::from(format!("tests/{}", mode));
-        config.target_rustcflags = Some("-L target/debug -L target/debug/deps".to_string());
-
-        compiletest::run_tests(&config);
-    }
-
-    #[test]
-    fn expected_failures() {
-        run_mode("compile-fail");
-    }
-}

--- a/tests/z85.rs
+++ b/tests/z85.rs
@@ -33,12 +33,12 @@ fn test_decode_errors() {
     }
 }
 
+/*
 // Valid input for z85 encoding (i.e. a slice of bytes with its length
 // being a multiple of 4)
 #[derive(Clone, Debug)]
 struct Input(Vec<u8>);
 
-/*
 // Disabled because quickcheck doesn't expose gen_range and gen anymore
 
 impl Arbitrary for Input {


### PR DESCRIPTION
- **Recommit Rust 1.83 compile-fail output**
- **Automatically fix new clippy lints on Rust 1.83**
- **Drop stale `compiletest` code**
- **Manually fix remaining clippy lints**
