### PR TITLE
Message: impl `AsRef<[u8]>`, `AsMut<[u8]>`

### DIFF
--- a/src/message.rs
+++ b/src/message.rs
@@ -192,6 +192,18 @@ impl DerefMut for Message {
     }
 }
 
+impl AsRef<[u8]> for Message {
+    fn as_ref(&self) -> &[u8] {
+        self.deref()
+    }
+}
+
+impl AsMut<[u8]> for Message {
+    fn as_mut(&mut self) -> &mut [u8] {
+        self.deref_mut()
+    }
+}
+
 impl<'a> From<&'a [u8]> for Message {
     /// Construct a message from a byte slice by copying the data.
     fn from(data: &'a [u8]) -> Self {


### PR DESCRIPTION
Rationale: this complements the `Deref` and `DerefMut` impls, and allows Message to be used directly in I/O constructs like `std::io::Cursor`, which makes it a lot easier to implement reads.