### PR TITLE
Update zmq-sys dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,7 @@ zmq_has = []
 [dependencies]
 bitflags = "1.0"
 libc = "0.2.15"
-zmq-sys = { version = "0.12.0", path = "zmq-sys" }
+zmq-sys = { version = "0.13.0", path = "zmq-sys" }
 
 [dev-dependencies]
 trybuild = { version = "1" }

--- a/zmq-sys/Cargo.toml
+++ b/zmq-sys/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zmq-sys"
-version = "0.12.1"
+version = "0.13.0"
 authors = [
     "a.rottmann@gmx.at",
     "erick.tryzelaar@gmail.com",
@@ -20,7 +20,7 @@ libc = "0.2.25"
 
 [build-dependencies]
 system-deps = "6"
-zeromq-src = "0.3.6"
+zeromq-src = "0.3.6+4.3.5"
 
 [package.metadata.system-deps]
 libzmq = "4.3.5"

--- a/zmq-sys/Cargo.toml
+++ b/zmq-sys/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zmq-sys"
-version = "0.12.0"
+version = "0.12.1"
 authors = [
     "a.rottmann@gmx.at",
     "erick.tryzelaar@gmail.com",
@@ -16,11 +16,11 @@ links = "zmq"
 [features]
 
 [dependencies]
-libc = "0.2.15"
+libc = "0.2.25"
 
 [build-dependencies]
 system-deps = "6"
-zeromq-src = "0.3"
+zeromq-src = "0.3.6"
 
 [package.metadata.system-deps]
-libzmq = "4.1"
+libzmq = "4.3.5"


### PR DESCRIPTION
This fixes https://github.com/erickt/rust-zmq/issues/414 thanks to https://github.com/jean-airoldie/zeromq-src-rs/issues/49 for windows cross compilation (`cross build --target x86_64-pc-windows-gnu`).
